### PR TITLE
Update LiveFetch docs as the functions are now available to all users

### DIFF
--- a/query-engine/Functions-and-operators/live-fetch.mdx
+++ b/query-engine/Functions-and-operators/live-fetch.mdx
@@ -30,10 +30,6 @@ SELECT * FROM UNNEST(
   </Card>
 </CardGroup>
 
-<Warning>
-The LiveFetch functions are only available for customers on a paid plan.
-</Warning>
-
 ## API support and credentials
 
 There are no limits to the supported APIs. The URL can point to any public or private API.


### PR DESCRIPTION
Towards https://linear.app/dune/issue/NGN-1638/make-livefetch-functions-available-to-free-plans

This can be merged now. The access change is effective in prod.