### PR TITLE
docs: base64 encoding format

### DIFF
--- a/api-reference/tables/endpoint/insert.mdx
+++ b/api-reference/tables/endpoint/insert.mdx
@@ -25,7 +25,15 @@ Each line must have keys that match the column names of the table.
 ## Data types
 DuneSQL supports a variety of types which are not natively supported in many data exchange formats. Here we provide guidance on how to work with such types.
 ### Varbinary values
-When uploading varbinary data using JSON or CSV formats, you need to convert the binary data into its hexadecimal textual representation. Specifically, input data should contain an even number of characters in the range `[0-9a-fA-F]` always prefixed with `0x`.
+When uploading varbinary data using JSON or CSV formats, you need to convert the binary data into a textual representation. Reason being, JSON or CSV don't natively support binary values. There are many ways to transform binary data to a textual representation. We support **hexadecimal** and **base64** encodings.
+
+#### base64
+Base64 is a binary-to-text encoding scheme that transforms binary data into a sequence of characters. All characters are taken from a set of 64 characters.
+
+Example: `{"varbinary_column":"SGVsbG8gd29ybGQK"}`
+
+#### hexadecimal
+In the hexadecimal representation input data should contain an even number of characters in the range `[0-9a-fA-F]` always prefixed with `0x`.
 
 Example: `{"varbinary_column":"0x92b7d1031988c7af"}`
 


### PR DESCRIPTION
We provide documentation for the two alternative formats we support for binary to text convertion.

![Screenshot 2024-04-30 at 12 58 55 PM](https://github.com/duneanalytics/dune-docs/assets/7823083/b72aed1e-6fc1-4597-8226-f98d1b5fb178)
