### PR TITLE
Reworked API Doc section in light of new API naming

### DIFF
--- a/api-reference/executions/execution-object.mdx
+++ b/api-reference/executions/execution-object.mdx
@@ -1,6 +1,11 @@
 ---
 title: 'Overview'
+icon: "star"
 ---
+
+The executions and results endpoints facilitate the execution of saved queries, retrieval of results in various formats, and management of query executions. 
+
+## Queries, Executions, and Results
 
 Results are linked to executions, and executions are tied to queries. Each execution has an `execution_id`. An `execution_id` is generated when you initiate the execution of a query through the [execute query](./endpoint/execute-query) endpoint.
 
@@ -45,9 +50,9 @@ Two primary methods exist for fetching data from the Dune API while applying spe
 - Option 1 offers speed, as it builds upon existing results with filters. Use it when quick results are essential.
 - Option 2 allows dynamic parameter passing for fresh executions. Employ it when real-time parameterization is required.
 
-## Dune API Endpoints Overview
+## Endpoints
 
-Dune API offers a range of endpoints under the categories of "Execution" and "Results". These endpoints facilitate the execution of predefined queries, retrieval of results in various formats, and management of query executions. Below is an overview of each endpoint, providing a high-level understanding of their functionalities.
+Below is an overview of each endpoint, providing a high-level understanding of their functionalities.
 
 
 | Endpoint Title           | Endpoint                          | Description                                                                                   |

--- a/api-reference/farcaster/introduction.mdx
+++ b/api-reference/farcaster/introduction.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Farcaster Introduction"
+title: "Dune Farcaster API"
 ---
 
 While you can create/use any query as an API endpoint, we've defined three popular queries as custom endpoints (so you don't need to worry about executions or editing SQL). You should use these endpoints to provide better data to inform your algorithims, recomendations, or UI elements.

--- a/api-reference/overview/authentication.mdx
+++ b/api-reference/overview/authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: Authentication
+icon: "user"
 ---
 
 The Dune API relies on API keys for authentication. Your API key grants access and determines billing details for private queries, so safeguard it diligently!

--- a/api-reference/overview/billing.mdx
+++ b/api-reference/overview/billing.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Billing'
+icon: "file-invoice-dollar"
 ---
 
 Pricing for API is charged along two dimensions. All details can be found at [dune.com/pricing](https://dune.com/pricing)

--- a/api-reference/overview/faq.mdx
+++ b/api-reference/overview/faq.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'FAQ'
+icon: "message-question"
 ---
 
 #### What are the differences between the Dune API and the Dune web app?

--- a/api-reference/overview/introduction.mdx
+++ b/api-reference/overview/introduction.mdx
@@ -1,80 +1,103 @@
 ---
-title: "Introduction"
+title: "Dune API Overview"
+icon: "connectdevelop"
 ---
 
-Dune's four general API offerings can be found below:
+Dune API provides a variety of endpoints for developers, ranging from low-level, customizable options to high-level, preset endpoints ready for immediate use.
 
-<CardGroup cols={2}>
+## SQL Endpoints
+They help you manage and execute queries, as well as fetch data from these queries.
+
+<CardGroup cols={3}>
   <Card
-    title="SQL Endpoints"
+    title="Executions and Results"
     icon="cloud-arrow-down"
     href="/api-reference/executions/execution-object"
   >
-    Execute queries and get results in JSON or CSV form
+    Execute queries and retrieve results in JSON or CSV format.
   </Card>
   <Card
     title="Query Management"
     icon="floppy-disk"
     href="/api-reference/queries/endpoint/query-object"
   >
-    Manage your queries through the API, good for combining with GitHub.
-  </Card>
-  <Card
-    title="Data Upload and Table Management"
-    icon="upload"
-    href="/api-reference/tables/endpoint/create"
-  >
-    Upload data into Dune to create your own queryable tables
+    Manage your queries through the API, ideal for integration with GitHub.
   </Card>
   <Card title="Webhooks" icon="webhook" href="/api-reference/webhooks/webhook">
-    Push Dune data into your own webhooks, on a custom set schedule
+    Push Dune data to your webhooks on a custom schedule.
+  </Card>
+</CardGroup>
+
+## Data Management Endpoints
+They help you upload and manage data on Dune.
+
+<CardGroup cols={2}>
+  <Card
+    title="Table Management"
+    icon="upload"
+    href="/api-reference/tables/endpoint/overview"
+  >
+    Upload data to Dune to create queryable tables.
+  </Card>
+
+  <Card
+    title="Hosted Blockchain Integration"
+    icon="hive"
+    href="/api-reference/tables/blockchain/overview"
+  >
+    Integrate your blockchain data with Dune using dedicated API endpoints. (_Enterprise only_)
   </Card>
 </CardGroup>
 
 ## Preset Endpoints
-We also have preset endpoints for common data themes developers build with:
+These are curated endpoints built by Dune, ready for immediate use. No SQL required. Developers can use these endpoints to access data on popular topics.
 
-<CardGroup cols={2}>
-  <Card
-    title="Farcaster"
-    icon="thumbs-up"
-    href="/api-reference/farcaster/introduction"
-  >
-    Get trending users, channels, and memecoins
-  </Card>
-  <Card
-    title="EigenLayer"
-    icon="layer-group"
-    href="/api-reference/eigenlayer/introduction"
-  >
-    Get metadata and metrics for Eigenlayer AVSs and Operators
-  </Card>
-  <Card
-    title="Projects"
-    icon="diagram-project"
-    href="/api-reference/projects/introduction"
-  >
-    Get API endpoints specific to a project or a protocol
-  </Card>
+<CardGroup cols={3}>
   <Card
     title="Contracts"
     icon="file-contract"
     href="/api-reference/evm/endpoint/contracts"
   >
-    Get trending EVM contracts by contract type, project, name, users, and value
+    Get trending EVM contracts by type, project, name, users, and value.
   </Card>
+  
   <Card
     title="DEX"
     icon="money-bill-trend-up"
     href="/api-reference/dex/endpoint/dex_pair"
   >
-    Get token pair stats
+    Get statistics for token pairs.
   </Card>
+  
+  <Card
+    title="EigenLayer"
+    icon="layer-group"
+    href="/api-reference/eigenlayer/introduction"
+  >
+    Get metadata and metrics for EigenLayer AVSs and operators.
+  </Card>
+
+  <Card
+    title="Farcaster"
+    icon="thumbs-up"
+    href="/api-reference/farcaster/introduction"
+  >
+    Get trending users, channels, and memecoins.
+  </Card>
+
   <Card
     title="Markets"
     icon="shop"
     href="/api-reference/markets/endpoint/marketplace_marketshare"
   >
-    Track DEX/NFT market share
+    Track DEX and NFT market share.
+  </Card>
+
+  <Card
+    title="Projects"
+    icon="diagram-project"
+    href="/api-reference/projects/introduction"
+  >
+    Access API endpoints specific to various projects and protocols.
   </Card>
 </CardGroup>

--- a/api-reference/overview/rate-limits.mdx
+++ b/api-reference/overview/rate-limits.mdx
@@ -1,5 +1,6 @@
 ---
 title: Rate Limits
+icon: "wave-pulse"
 ---
 
 **Rate Limits**

--- a/api-reference/overview/sdks.mdx
+++ b/api-reference/overview/sdks.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Client SDKs'
+icon: "sd-cards"
 ---
 
 ## Python

--- a/api-reference/overview/troubleshooting.mdx
+++ b/api-reference/overview/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting Errors
+icon: "square-question"
 ---
 
 Dune uses conventional HTTP response codes to indicate the success or failure of an API request. In general: Codes in the `2xx` range indicate success. Codes in the `4xx` range indicate an error that failed given the information provided. Codes in the `5xx` range indicate an error with Dune's servers.

--- a/api-reference/queries/endpoint/query-object.mdx
+++ b/api-reference/queries/endpoint/query-object.mdx
@@ -1,6 +1,9 @@
 ---
-title: 'Queries and parameters'
+title: 'Overview'
+icon: "star"
 ---
+
+These query management endspoints help you programmatically create and manage Dune SQL queries via the API, ideal for integration with GitHub or other CI/CD pipelines.
 
 ### Queries
 

--- a/api-reference/tables/endpoint/overview.mdx
+++ b/api-reference/tables/endpoint/overview.mdx
@@ -1,0 +1,8 @@
+---
+title: 'Overview'
+icon: "star"
+---
+
+These table management endspoints help you programmatically upload data to Dune and manage tables via the API.
+
+To upload data, while you can use the [`/upload endpoint`](./upload), consider using the [`/create`](./create) and [`/insert`](./insert) endpoints for more flexibility, performance, and the ability to append.

--- a/data-catalog/evm/overview.mdx
+++ b/data-catalog/evm/overview.mdx
@@ -16,11 +16,9 @@ All EVM chains on Dune have raw data, decoded data and curated data tables avail
 e.g. here are the available data sets for Ethereum Mainnet:
 
 <CardGroup cols={3}>
-  <Card title="Raw data" icon="bolt" href="./ethereum/raw/transactions">
-    </Card>
-  <Card title="Decoded data" icon="file" href="./ethereum/decoded/overview">
-  </Card>
-    <Card title="Curated data" icon="star" href="/data-catalog/spellbook/overview"></Card>
+  <Card title="Raw data" icon="bolt" href="./ethereum/raw/transactions"/>
+  <Card title="Decoded data" icon="file" href="./ethereum/decoded/overview"/>
+  <Card title="Curated data" icon="star" href="/data-catalog/spellbook/overview"/>
 </CardGroup>
 
 

--- a/mint.json
+++ b/mint.json
@@ -128,48 +128,47 @@
         "query-engine/reserved-keywords"
       ]
     },
-    
-        {
-          "group": "Functions and Operators",
-          "pages": [
-            "query-engine/Functions-and-operators/index",
-            "query-engine/Functions-and-operators/aggregate",
-            "query-engine/Functions-and-operators/array",
-            "query-engine/Functions-and-operators/base58",
-            "query-engine/Functions-and-operators/binary",
-            "query-engine/Functions-and-operators/bitwise",
-            "query-engine/Functions-and-operators/chain-utility-functions",
-            "query-engine/Functions-and-operators/comparison",
-            "query-engine/Functions-and-operators/conditional",
-            "query-engine/Functions-and-operators/conversion",
-            "query-engine/Functions-and-operators/datetime",
-            "query-engine/Functions-and-operators/decimal",
-            "query-engine/Functions-and-operators/hyperloglog",
-            "query-engine/Functions-and-operators/json",
-            "query-engine/Functions-and-operators/lambda",
-            "query-engine/Functions-and-operators/live-fetch",
-            "query-engine/Functions-and-operators/logical",
-            "query-engine/Functions-and-operators/map",
-            "query-engine/Functions-and-operators/math",
-            "query-engine/Functions-and-operators/ml",
-            "query-engine/Functions-and-operators/qdigest",
-            "query-engine/Functions-and-operators/regexp",
-            "query-engine/Functions-and-operators/setdigest",
-            "query-engine/Functions-and-operators/ss58",
-            "query-engine/Functions-and-operators/tronaddress",
-            "query-engine/Functions-and-operators/string",
-            "query-engine/Functions-and-operators/system",
-            "query-engine/Functions-and-operators/tdigest",
-            "query-engine/Functions-and-operators/teradata",
-            "query-engine/Functions-and-operators/url",
-            "query-engine/Functions-and-operators/uuid",
-            "query-engine/Functions-and-operators/varbinary",
-            "query-engine/Functions-and-operators/varchar-utility-functions",
-            "query-engine/Functions-and-operators/window"
-          ]
-        },
-      
-    
+
+    {
+      "group": "Functions and Operators",
+      "pages": [
+        "query-engine/Functions-and-operators/index",
+        "query-engine/Functions-and-operators/aggregate",
+        "query-engine/Functions-and-operators/array",
+        "query-engine/Functions-and-operators/base58",
+        "query-engine/Functions-and-operators/binary",
+        "query-engine/Functions-and-operators/bitwise",
+        "query-engine/Functions-and-operators/chain-utility-functions",
+        "query-engine/Functions-and-operators/comparison",
+        "query-engine/Functions-and-operators/conditional",
+        "query-engine/Functions-and-operators/conversion",
+        "query-engine/Functions-and-operators/datetime",
+        "query-engine/Functions-and-operators/decimal",
+        "query-engine/Functions-and-operators/hyperloglog",
+        "query-engine/Functions-and-operators/json",
+        "query-engine/Functions-and-operators/lambda",
+        "query-engine/Functions-and-operators/live-fetch",
+        "query-engine/Functions-and-operators/logical",
+        "query-engine/Functions-and-operators/map",
+        "query-engine/Functions-and-operators/math",
+        "query-engine/Functions-and-operators/ml",
+        "query-engine/Functions-and-operators/qdigest",
+        "query-engine/Functions-and-operators/regexp",
+        "query-engine/Functions-and-operators/setdigest",
+        "query-engine/Functions-and-operators/ss58",
+        "query-engine/Functions-and-operators/tronaddress",
+        "query-engine/Functions-and-operators/string",
+        "query-engine/Functions-and-operators/system",
+        "query-engine/Functions-and-operators/tdigest",
+        "query-engine/Functions-and-operators/teradata",
+        "query-engine/Functions-and-operators/url",
+        "query-engine/Functions-and-operators/uuid",
+        "query-engine/Functions-and-operators/varbinary",
+        "query-engine/Functions-and-operators/varchar-utility-functions",
+        "query-engine/Functions-and-operators/window"
+      ]
+    },
+
     {
       "group": "",
       "pages": [
@@ -820,23 +819,34 @@
     },
 
     {
-      "group": "API Documentation",
+      "group": "",
       "pages": [
         "api-reference/overview/introduction",
+        {
+          "group": "API Quickstart",
+          "pages": [
+            "api-reference/quickstart/results-eg",
+            "api-reference/quickstart/queries-eg",
+            "api-reference/quickstart/tables-eg"
+          ],
+          "icon": "forward-fast"
+        },
         "api-reference/overview/authentication",
         "api-reference/overview/sdks",
+        {
+          "group": "Result Filtering",
+          "pages": [
+            "api-reference/executions/pagination",
+            "api-reference/executions/filtering",
+            "api-reference/executions/sorting",
+            "api-reference/executions/sampling"
+          ],
+          "icon": "filter"
+        },
         "api-reference/overview/rate-limits",
         "api-reference/overview/troubleshooting",
         "api-reference/overview/billing",
         "api-reference/overview/faq"
-      ]
-    },
-    {
-      "group": "API Quickstart",
-      "pages": [
-        "api-reference/quickstart/results-eg",
-        "api-reference/quickstart/queries-eg",
-        "api-reference/quickstart/tables-eg"
       ]
     },
     {
@@ -846,10 +856,6 @@
           "group": "Executions and Results",
           "pages": [
             "api-reference/executions/execution-object",
-            "api-reference/executions/pagination",
-            "api-reference/executions/filtering",
-            "api-reference/executions/sorting",
-            "api-reference/executions/sampling",
             "api-reference/executions/endpoint/execute-query",
             "api-reference/executions/endpoint/cancel-execution",
             "api-reference/executions/endpoint/get-execution-status",
@@ -892,6 +898,7 @@
         {
           "group": "Tables",
           "pages": [
+            "api-reference/tables/endpoint/overview",
             "api-reference/tables/endpoint/create",
             "api-reference/tables/endpoint/insert",
             "api-reference/tables/endpoint/upload",
@@ -904,13 +911,14 @@
     {
       "group": "Realtime (Beta)",
       "pages": [
-        {   "group": "Account APIs",
-            "pages": [
+        {
+          "group": "Account APIs",
+          "pages": [
             "api-reference/realtime/overview",
             "api-reference/realtime/balances",
             "api-reference/realtime/chains"
           ]
-          }
+        }
       ]
     },
     {

--- a/mint.json
+++ b/mint.json
@@ -909,7 +909,7 @@
       ]
     },
     {
-      "group": "Realtime (Beta)",
+      "group": "Realtime Endpoints (Beta)",
       "pages": [
         {
           "group": "Account APIs",

--- a/mint.json
+++ b/mint.json
@@ -885,7 +885,7 @@
       ]
     },
     {
-      "group": "Data Management",
+      "group": "Data Management Endpoints",
       "pages": [
         {
           "group": "Blockchains",


### PR DESCRIPTION
1. Reworked the landing page on API Reference header section 
2. Moved pagination, filtering, sorting and sampling to a higher level because they apply not only to SQL Endpoints to also to Preset and soon to be Custom Endpoints
3. Put API Quickstart as a collapsible section instead of it's own highest level section. We are adding top level sections very fast with SDK, Realtime and soon to be Custom. The top level headers are getting too much hence reducing it a bit. 

![image](https://github.com/duneanalytics/dune-docs/assets/5827114/53366103-848c-4144-9afe-800e0faa2b95)

Calling out things I'm not sure/ need more thinking 
- "Data Management Endpoints" as a name --> when we discussed naming of API we didn't decide on how to call this group of API, so for now I'm adding "Endpoints" at the end so make everything consistent
- "Result Filtering" as a category name for pagination, filtering, sorting and sampling. Out of like 20 names I've chatted with ChatGPT on how to name them, this is the one that resonates the best with me, but I'm open to change
- Related, there is a separate PR on making SDK doc it's top level section: https://github.com/duneanalytics/dune-docs/pull/176