### PR TITLE
Demo for table descriptions

### DIFF
--- a/data-catalog/evm/mantle/raw/transactions.mdx
+++ b/data-catalog/evm/mantle/raw/transactions.mdx
@@ -7,6 +7,6 @@ description: Description of the mantle.transactions table on Dune
 import { TransactionsSnippet } from '/snippets/evm/raw/transactions-snippet.mdx';
 import { ColumnDescriptions } from "/snippets/column-descriptions.mdx";
 import { TableSample } from "/snippets/table-sample.mdx";
+import { tableDescription } from '/snippets/table-descriptions.mdx';
 
-
-<TransactionsSnippet blockchain="mantle" />
+<TransactionsSnippet blockchain="mantle" tableDescription={tableDescription["mantle.transactions"]} />

--- a/snippets/evm/raw/transactions-snippet.mdx
+++ b/snippets/evm/raw/transactions-snippet.mdx
@@ -1,11 +1,8 @@
-export const TransactionsSnippet = ({ blockchain }) => (
+export const TransactionsSnippet = ({ blockchain, tableDescription }) => (
   <div>
     <h2>Table Description</h2>
     <p>
-      The <code>{blockchain}.transactions</code> table contains information about all transactions on the {blockchain} blockchain. Each row represents a single transaction and includes information such as block number, hash, timestamp, sender, recipient, value, gas, gas price, and more. Transactions are the fundamental unit of interaction with the {blockchain} blockchain. Transactions are created by users and are used to send value, deploy smart contracts, and interact with smart contracts.
-    </p>
-    <p>
-      This is the raw version of this table, for decoded transaction calls, see the <a href={`/data-catalog/evm/${blockchain}/decoded/call-tables`}>call tables</a> section.
+      {tableDescription}
     </p>
     <h2>Column Descriptions</h2>
     <ColumnDescriptions tableSchema={blockchain} tableName="transactions" />

--- a/snippets/evm/raw/transactions-snippet.mdx
+++ b/snippets/evm/raw/transactions-snippet.mdx
@@ -1,8 +1,7 @@
 export const TransactionsSnippet = ({ blockchain, tableDescription }) => (
   <div>
     <h2>Table Description</h2>
-    <p>
-      {tableDescription}
+    <p dangerouslySetInnerHTML={{__html: tableDescription }} >
     </p>
     <h2>Column Descriptions</h2>
     <ColumnDescriptions tableSchema={blockchain} tableName="transactions" />

--- a/snippets/table-descriptions.mdx
+++ b/snippets/table-descriptions.mdx
@@ -1,8 +1,8 @@
 export const tableDescription = { 
   "mantle.transactions": `<p>
-      The <code>mantle.transactions</code> table contains information about all transactions on the mantle blockchain. Each row represents a single transaction and includes information such as block number, hash, timestamp, sender, recipient, value, gas, gas price, and more. Transactions are the fundamental unit of interaction with the {blockchain} blockchain. Transactions are created by users and are used to send value, deploy smart contracts, and interact with smart contracts.
+      The <code>mantle.transactions</code> table contains information about all transactions on the mantle blockchain. Each row represents a single transaction and includes information such as block number, hash, timestamp, sender, recipient, value, gas, gas price, and more. Transactions are the fundamental unit of interaction with the blockchain. Transactions are created by users and are used to send value, deploy smart contracts, and interact with smart contracts.
     </p>
     <p>
-      This is the raw version of this table, for decoded transaction calls, see the <a href="/data-catalog/evm/mantle/decoded/call-tables">call tables</a> section.
+      This is the raw version of this table, for decoded transaction calls, see the <a href="../decoded/call-tables">call tables</a> section.
     </p>`, 
 };

--- a/snippets/table-descriptions.mdx
+++ b/snippets/table-descriptions.mdx
@@ -1,6 +1,6 @@
 export const tableDescription = { 
   "mantle.transactions": `<p>
-      The <code>{blockchain}.transactions</code> table contains information about all transactions on the {blockchain} blockchain. Each row represents a single transaction and includes information such as block number, hash, timestamp, sender, recipient, value, gas, gas price, and more. Transactions are the fundamental unit of interaction with the {blockchain} blockchain. Transactions are created by users and are used to send value, deploy smart contracts, and interact with smart contracts.
+      The <code>mantle.transactions</code> table contains information about all transactions on the mantle blockchain. Each row represents a single transaction and includes information such as block number, hash, timestamp, sender, recipient, value, gas, gas price, and more. Transactions are the fundamental unit of interaction with the {blockchain} blockchain. Transactions are created by users and are used to send value, deploy smart contracts, and interact with smart contracts.
     </p>
     <p>
       This is the raw version of this table, for decoded transaction calls, see the <a href="/data-catalog/evm/mantle/decoded/call-tables">call tables</a> section.

--- a/snippets/table-descriptions.mdx
+++ b/snippets/table-descriptions.mdx
@@ -1,0 +1,8 @@
+export const tableDescription = { 
+  "mantle.transactions": `<p>
+      The <code>{blockchain}.transactions</code> table contains information about all transactions on the {blockchain} blockchain. Each row represents a single transaction and includes information such as block number, hash, timestamp, sender, recipient, value, gas, gas price, and more. Transactions are the fundamental unit of interaction with the {blockchain} blockchain. Transactions are created by users and are used to send value, deploy smart contracts, and interact with smart contracts.
+    </p>
+    <p>
+      This is the raw version of this table, for decoded transaction calls, see the <a href="/data-catalog/evm/mantle/decoded/call-tables">call tables</a> section.
+    </p>`, 
+};


### PR DESCRIPTION
What was done: 

1. Define a snippet that can hold all table descriptions. Here we use `mantle.transactions`. This would be autogenerated by spellbook data. 
2. Fill it with the current string, to validate it can do the same job as what we do atm
3. Import this variable into the table .mdx file
4. Pass it to the transaction table description

Works!

The blow example table description is now fetched from the variable:

![Screenshot 2024-06-07 at 12 50 05](https://github.com/duneanalytics/dune-docs/assets/22848/83c213d8-0cef-4911-9eb6-99fa4e2b4ed8)