### PR TITLE
Updates to prices docs

### DIFF
--- a/data-catalog/curated/prices/overview.mdx
+++ b/data-catalog/curated/prices/overview.mdx
@@ -55,7 +55,7 @@ All price tables share the following schema:
 
 | Column             | Type        | Description                                                                      |
 | ------------------ | ----------- | -------------------------------------------------------------------------------- |
-| `contract_address` | _varbinary_ | Token identifier (ERC20 contract address, Solana mint address, null for natives) |
+| `contract_address` | _varbinary_ | Token identifier (ERC20 contract address, Solana mint address, 0x00..00 for natives) |
 | `blockchain`       | _varchar_   | Network identifier                                                               |
 | `symbol`           | _varchar_   | Token symbol                                                                     |
 | `price`            | _double_    | USD price                                                                        |
@@ -71,7 +71,7 @@ All price tables share the following schema:
 
 ## Methodology
 
-Dune's price data is derived primarily from DEX trading activity captured in [`dex.trades`](/data-catalog/curated/evm/DEX/dex-trades), providing broad coverage across 180,000+ tokens and 20+ blockchains. The data undergoes rigorous processing including volume filtering, outlier removal, and VWAP calculations to ensure accuracy and reliability. This methodology enables automatic price tracking for any token that achieves meaningful trading volume (>$10k), while maintaining data quality through statistical controls.  
+Dune's price data is derived primarily from DEX trading activity captured in [`dex.trades`](/data-catalog/curated/evm/DEX/dex-trades), providing broad coverage across 180,000+ tokens and 20+ blockchains. The data undergoes rigorous processing including volume filtering, outlier removal, and VWAP calculations to ensure accuracy and reliability. This methodology enables automatic price tracking for any token that achieves meaningful trading volume (>$10k), while maintaining data quality through statistical controls.
 Despite comprehensive internal testing and measures to prevent data errors, it's possible for prices to be inaccurate due to outlier trades (arbitrage, hacks etc.) which can skew the data. If you happen to notice a price error, please open an issue on [GitHub](https://github.com/duneanalytics/spellbook/issues).
 
 ### Step 1: Importing Trusted Token Prices

--- a/data-catalog/curated/prices/prices_day.mdx
+++ b/data-catalog/curated/prices/prices_day.mdx
@@ -26,16 +26,16 @@ This table is ideal for analyzing daily price trends and performing day-over-day
 ## Example Query
 
 ```sql
-SELECT 
+SELECT
     contract_address,
     blockchain,
     symbol,
     price,
     timestamp
 FROM prices.day
-WHERE 
-    blockchain = 'ethereum' 
-    AND symbol = 'WETH'
+WHERE
+    blockchain = 'ethereum'
+    AND contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 -- WETH
     AND timestamp >= DATE '2023-01-01'
 ORDER BY timestamp asc
 ```

--- a/data-catalog/curated/prices/prices_hour.mdx
+++ b/data-catalog/curated/prices/prices_hour.mdx
@@ -26,13 +26,18 @@ This table is useful for intraday analysis and tracking price movements with hig
 ## Example Query
 
 ```sql
-SELECT 
+SELECT
     contract_address,
     blockchain,
     symbol,
     price,
     timestamp
 FROM prices.hour
+WHERE
+    blockchain = 'ethereum'
+    AND contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 -- WETH
+    AND timestamp >= NOW() - INTERVAL '7' DAY
+ORDER BY timestamp asc
 ```
 
 ## Notes

--- a/data-catalog/curated/prices/prices_latest.mdx
+++ b/data-catalog/curated/prices/prices_latest.mdx
@@ -23,13 +23,13 @@ Example query using modern tables:
 
 ```sql
 -- For latest prices, use prices.minute with recent timestamp
-SELECT 
-    symbol, 
-    price 
+SELECT
+    symbol,
+    price
 FROM prices.minute
 WHERE blockchain = 'ethereum'
-    AND symbol = 'WETH'
-    AND timestamp >= NOW() - INTERVAL '5' MINUTE
+    AND contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 -- WETH
+    AND timestamp >= NOW() - INTERVAL '1' HOUR
 ORDER BY timestamp DESC
 LIMIT 1
 ```

--- a/data-catalog/curated/prices/prices_minute.mdx
+++ b/data-catalog/curated/prices/prices_minute.mdx
@@ -25,13 +25,13 @@ This table is ideal for high-frequency analysis and examining short-term price m
 ## Example Query
 
 ```sql
-SELECT 
+SELECT
     timestamp,
     price
 FROM prices.minute
-WHERE 
-    blockchain = 'ethereum' 
-    AND symbol = 'WETH'
+WHERE
+    blockchain = 'ethereum'
+    AND contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 -- WETH
     AND timestamp >= NOW() - INTERVAL '1' HOUR
 ORDER BY timestamp
 ```

--- a/data-catalog/curated/prices/prices_usd.mdx
+++ b/data-catalog/curated/prices/prices_usd.mdx
@@ -24,15 +24,18 @@ Example query using modern tables:
 
 ```sql
 -- For historical prices, use prices.day
-SELECT 
-    timestamp,
-    symbol, 
-    price 
+SELECT
+    contract_address,
+    blockchain,
+    symbol,
+    price,
+    timestamp
 FROM prices.day
-WHERE blockchain = 'ethereum'
-    AND symbol = 'WETH'
+WHERE
+    blockchain = 'ethereum'
+    AND contract_address = 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 -- WETH
     AND timestamp >= DATE '2023-01-01'
-ORDER BY timestamp ASC
+ORDER BY timestamp asc
 ```
 
 ## Legacy Table Structure
@@ -45,4 +48,4 @@ ORDER BY timestamp ASC
 | `timestamp`       | _timestamp_ | The timestamp for which this price is reported |
 | `blockchain`      | _varchar_   | The blockchain on which the asset exists      |
 
-For more information about the current price feed, please refer to the [Prices Overview](/data-catalog/curated/prices/overview). 
+For more information about the current price feed, please refer to the [Prices Overview](/data-catalog/curated/prices/overview).


### PR DESCRIPTION
1. updates to the example queries to use contract_address instead of symbol
2. mention that native tokens are fount at `0x00.00` instead of null