### PR TITLE
fix: typos in documentation files

### DIFF
--- a/web-app/alerts.mdx
+++ b/web-app/alerts.mdx
@@ -182,7 +182,7 @@ Once saved, you will start receiving messages on Slack. Here is an example of ho
 
 ### Zapier Integration
 
-[Zapier](https://zapier.com/) is a third party solution that supports building integrations betwen different software solutions without writing any code. With it you can build advanced workflows that relay data between Dune and your favorite work tools.
+[Zapier](https://zapier.com/) is a third party solution that supports building integrations between different software solutions without writing any code. With it you can build advanced workflows that relay data between Dune and your favorite work tools.
 
 We currently offer an experimental [Zapier app](https://zapier.com/developer/public-invite/194504/2174c6b998748b657f28dab4097f3e80/) to support connecting Dune with thousands of other tools via Zapier. 
 

--- a/web-app/dashboard-minting.mdx
+++ b/web-app/dashboard-minting.mdx
@@ -23,7 +23,7 @@ After you select an amount and click mint, Dune will take a screenshot and creat
 
 ![](/web-app/images/mint_moment_tx.PNG)
 
-This is showing you the number of tokens you will recieve, and how much ETH you are spending + gas fees. After you confirm, it should only take a second before you see a successful mint screen:
+This is showing you the number of tokens you will receive, and how much ETH you are spending + gas fees. After you confirm, it should only take a second before you see a successful mint screen:
 
 ![](/web-app/images/mint_moment_success.PNG)
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `betwen` to `between`
Corrected `recieve` to `receive`

Please review the changes and let me know if any additional changes are needed.

