### PR TITLE
Update BigQuery ML documentation link

### DIFF
--- a/query-engine/Functions-and-operators/ml.mdx
+++ b/query-engine/Functions-and-operators/ml.mdx
@@ -43,7 +43,7 @@ Classification is a type of supervised learning problem to predict the
 distinct label from the given feature vector. The interface looks
 similar to the construction of the SVM model from the sequence of pairs
 of labels and features implemented in Teradata Aster or [BigQuery
-ML](https://cloud.google.com/bigquery-ml/docs/bigqueryml-intro). The
+ML](https://cloud.google.com/bigquery/docs/bqml-introduction). The
 function to train a classification model looks like as follows:
 ```sql
     SELECT


### PR DESCRIPTION

Changes:
- File: query-engine/Functions-and-operators/ml.mdx
- Old: https://cloud.google.com/bigquery-ml/docs/bigqueryml-intro
- New: https://cloud.google.com/bigquery/docs/bqml-introduction

The original documentation link for BigQuery ML was outdated and returned a 404 error. Updated to point to the current official Google Cloud documentation.