### PR TITLE
 Fix Ttypos and grammar errors

### DIFF
--- a/api-reference/executions/pagination.mdx
+++ b/api-reference/executions/pagination.mdx
@@ -228,7 +228,7 @@ To paginate through results:
 
 ### Pagination in Response
 
-The following fields in the repsonse body are related to pagination and can be utilized when doing paginated get results request. If they are available, you can use them to paginate the next page. If they are not available, that means there are no more results to be fetched.
+The following fields in the response body are related to pagination and can be utilized when doing paginated get results request. If they are available, you can use them to paginate the next page. If they are not available, that means there are no more results to be fetched.
 
 <Tabs>
     <Tab title="JSON response endpoints">

--- a/api-reference/executions/sampling.mdx
+++ b/api-reference/executions/sampling.mdx
@@ -100,7 +100,7 @@ Our API supports sampling on all `/results` endpoints to provide a uniform sampl
 ### Sampling Response
 
 <Accordion title="Example sampling response">
-    _Showing trimmed reponse for `sample_count=200` instead of specified `sample_count=10000` in example request to not overwhelm the doc._
+    _Showing trimmed response for `sample_count=200` instead of specified `sample_count=10000` in example request to not overwhelm the doc._
     ```json
         {
             "execution_id": "01HR8D39V7N8WM653SVDW2G9WB",

--- a/api-reference/webhooks/webhook.mdx
+++ b/api-reference/webhooks/webhook.mdx
@@ -1,11 +1,11 @@
 ---
 title: 'Create Webhook'
-description: 'How to recieve data into webhooks from Dune queries'
+description: 'How to receive data into webhooks from Dune queries'
 icon: "webhook"
 iconType: "solid"
 ---
 
-You can send Dune data to a webhook by going to any query your own, and pressing the "schedule" button to the left of "Run" in the editor. You'll the popup below, where you can paste in a webhook url and recieve data on a scheduled interval.
+You can send Dune data to a webhook by going to any query your own, and pressing the "schedule" button to the left of "Run" in the editor. You'll the popup below, where you can paste in a webhook url and receive data on a scheduled interval.
 
 <Note>
 A good use case for this is sending data to a Slack webhook, which you can [learn to do here](https://api.slack.com/messaging/webhooks).
@@ -58,5 +58,5 @@ You'll need to GET query the `data_uri` with your api key to get the results dat
 </Note>
 
 <Warning>
-In the case the query errors out on its scheduled run, you won't recieve anything to the webhook.
+In the case the query errors out on its scheduled run, you won't receive anything to the webhook.
 </Warning>

--- a/data-catalog/starknet/overview.mdx
+++ b/data-catalog/starknet/overview.mdx
@@ -35,7 +35,7 @@ Starknet uses Cairo, a Turing-complete language designed for writing provable pr
 
 Starknet introduces a novel account model where each user interacts with the network through their account contracts. This model enhances security and flexibility, allowing for features like account abstraction and multi-sig wallets. Unlike the traditional EVM model, where accounts are either externally owned accounts (EOAs) or smart contracts, Starknet uses account contracts for both user accounts and smart contracts, allowing for more advanced features and customizability.
 
-See Starknet's documention on [Accounts](https://docs.starknet.io/architecture-and-concepts/accounts/introduction/) and [Contracts](https://docs.starknet.io/architecture-and-concepts/smart-contracts/contract-classes/) for more information
+See Starknet's documentation on [Accounts](https://docs.starknet.io/architecture-and-concepts/accounts/introduction/) and [Contracts](https://docs.starknet.io/architecture-and-concepts/smart-contracts/contract-classes/) for more information
 
 ### Starknet Transaction Lifecycle
 

--- a/data-catalog/substrate/balances.mdx
+++ b/data-catalog/substrate/balances.mdx
@@ -6,7 +6,7 @@ description: Description of Substrate balances tables on Dune.
 
 ## Table description
 
-The `balances` table (e.g. `polkadot.balances`) stores a snapshot of all account balances at the end of each day: `free`, `reserved`, `misc_frozen`, and their USD value, if avaiable.  
+The `balances` table (e.g. `polkadot.balances`) stores a snapshot of all account balances at the end of each day: `free`, `reserved`, `misc_frozen`, and their USD value, if available.  
 
 ## Column Descriptions
 

--- a/query-engine/Functions-and-operators/json.mdx
+++ b/query-engine/Functions-and-operators/json.mdx
@@ -1419,7 +1419,7 @@ the following requirements are met:
 Cast operations with supported link`character string types
 <string-data-types>` treat the input as a string, not validated as JSON.
 This means that a cast operation with a string-type input of invalid JSON
-results in a succesful cast to invalid JSON.
+results in a successful cast to invalid JSON.
 Instead, consider using the `json_parse` function to
 create validated JSON from a string.
 </Note>

--- a/query-engine/Functions-and-operators/setdigest.mdx
+++ b/query-engine/Functions-and-operators/setdigest.mdx
@@ -175,7 +175,7 @@ Examples:
 
 Returns a map containing the
 [Murmur3Hash128](https://en.wikipedia.org/wiki/MurmurHash#MurmurHash3)
-hashed values and the count of their occurences within the internal
+hashed values and the count of their occurrences within the internal
 `MinHash` structure belonging to `x`.
 
 `x` must be of type `setdigest`.

--- a/web-app/search.mdx
+++ b/web-app/search.mdx
@@ -11,7 +11,7 @@ You can access Dune's search functionality everywhere in the Dune App through th
 
 ## Refining your results
 
-Alternatively, you can head over to the [Discover page](https://dune.com/browse/dashboards) where you will find the extended results page, with additonal filters to apply, such as ranking by trending, favorites or recently created. You will find your search input which you can edit alongside these filters to refine your search on the sidebar next to the results list:
+Alternatively, you can head over to the [Discover page](https://dune.com/browse/dashboards) where you will find the extended results page, with additional filters to apply, such as ranking by trending, favorites or recently created. You will find your search input which you can edit alongside these filters to refine your search on the sidebar next to the results list:
 
 ![Search sidebar](/web-app/images/search/search_results.png)
 

--- a/zz_unused/transfers/erc1155-transfers.mdx
+++ b/zz_unused/transfers/erc1155-transfers.mdx
@@ -7,7 +7,7 @@ description: Event logs for ERC1155 token transfers on the Ethereum blockchain.
 ## Table description
 
 This table captures all `Transfer` event logs for ERC1155 token transfers on the Ethereum blockchain.
-This log is usually emitted when a `transfer` or `TransferFrom` function is called succesfully on an ERC1155 token contract.
+This log is usually emitted when a `transfer` or `TransferFrom` function is called successfully on an ERC1155 token contract.
 
 The table schema is always `ERC1155_{chain}.evt_Transfer` where `chain` is the respective EVM chain.
 

--- a/zz_unused/transfers/erc20-transfers.mdx
+++ b/zz_unused/transfers/erc20-transfers.mdx
@@ -7,7 +7,7 @@ description: Event logs for ERC20 token transfers on the Ethereum blockchain.
 ## Table description
 
 This table captures all `Transfer` event logs for ERC20 token transfers on its respective EVM blockchain.
-This log is emitted when a `transfer` or `TransferFrom` function is succesfully called on an ERC20 token contract.
+This log is emitted when a `transfer` or `TransferFrom` function is successfully called on an ERC20 token contract.
 
 The table schema is always `erc20_{chain}.evt_Transfer` where `chain` is the respective EVM chain.
 

--- a/zz_unused/transfers/erc721-transfers.mdx
+++ b/zz_unused/transfers/erc721-transfers.mdx
@@ -7,7 +7,7 @@ description: Event logs for ERC721 token transfers on the Ethereum blockchain.
 ## Table description
 
 This table captures all `Transfer` event logs for ERC721 token transfers on the Ethereum blockchain.
-This log is usually emitted when a `transfer` or `TransferFrom` function is called succesfully on an ERC721 token contract.
+This log is usually emitted when a `transfer` or `TransferFrom` function is called successfully on an ERC721 token contract.
 
 The table schema is always `erc721_{chain}.evt_Transfer` where `chain` is the respective EVM chain.
 


### PR DESCRIPTION
- Correcting typos such as "succesfully" to "successfully" and "reponse" to "response".
- Fixing grammatical inconsistencies in the documentation text for better clarity.

