### PR TITLE
add activity api docs

### DIFF
--- a/echo/evm/activity.mdx
+++ b/echo/evm/activity.mdx
@@ -1,0 +1,61 @@
+---
+title: 'Activity (Beta)'
+openapi: 'GET /activity/{address}'
+---
+
+<Note>
+This beta endpoint is currently only available in our dev environment: https://activity.dev.dunetech.io
+</Note>
+
+The Activity endpoint provides a real-time feed of on-chain activity for any EVM address, including token transfers (native, ERC20, ERC721), contract interactions, and transaction details.
+
+<Note>
+  - This endpoint is authenticated with a normal Dune API key
+  - Activity is returned in chronological order, with newest items first
+  - Supports multiple token standards:
+    - Native token transfers
+    - ERC20 token transfers with token metadata (symbol, decimals)
+    - ERC721 (NFT) transfers with token IDs
+  - Contract interactions include decoded function calls and parameters
+  - Human-readable descriptions are provided
+</Note>
+
+# Response Fields
+
+| Field | Description | Type |
+|--------|-------------|------|
+| activity | Array of activity items | array |
+| next_offset | Pagination cursor for next page | string |
+
+## Activity Item Fields
+
+| Field | Description | Type |
+|--------|-------------|------|
+| chain_id | ID of the blockchain where activity occurred | integer |
+| transaction_hash | Hash of the transaction | string |
+| type | Activity type: 'transfer', 'call', or 'mint' | string |
+| asset_type | Asset type: 'native', 'erc20', or 'erc721' | string |
+| token_address | Contract address of token (for ERC20/ERC721) | string |
+| from | Address initiating the activity | string |
+| to | Recipient address | string |
+| value | Amount transferred (in WEI) or contract call value | string |
+| id | Token ID (for ERC721 transfers) | string |
+| metadata | Additional context about the activity | object |
+| metadata.symbol | Token symbol (for ERC20) | string |
+| metadata.decimals | Token decimals (for ERC20) | integer |
+| metadata.description | Human-readable description of the activity | string |
+| function | Decoded function information (for contract calls) | object |
+| function.name | Name of the called function | string |
+| function.inputs | Array of decoded function parameters | array |
+
+# Ordering
+
+The data is ordered by descending block time, so that new activity will always be delivered first.
+
+# Pagination
+
+This endpoint uses cursor-based pagination. You can use the `limit` parameter to define the maximum page size.
+Results might at times be less than the maximum page size.
+The `next_offset` value is included in the initial response and can be utilized to fetch the next page of results by passing it as the `offset` query parameter in the next request.
+
+<Warning>You can only use the value from `next_offset` to set the `offset` parameter of the next page of results. Using your own `offset` value will not have any effect.</Warning>

--- a/echo/openapi.json
+++ b/echo/openapi.json
@@ -10,10 +10,131 @@
   },
   "servers": [
     {
-      "url": "https://api.dune.com/api"
+      "url": "https://api.dune.com/api",
+      "description": "Production server"
     }
   ],
   "paths": {
+    "/activity/{address}": {
+      "servers": [
+        {
+          "url": "https://activity.dev.dunetech.io",
+          "description": "Development server"
+        }
+      ],
+      "get": {
+        "tags": [
+          "activity"
+        ],
+        "summary": "Get EVM activity for a given address",
+        "description": "This endpoint returns a chronological feed of on-chain activity for any EVM address, including token transfers and contract interactions.",
+        "operationId": "getEvmActivity",
+        "parameters": [
+          {
+            "name": "X-Dune-Api-Key",
+            "in": "header",
+            "description": "API key to access the service",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "address",
+            "in": "path",
+            "description": "Address to get activity for",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "chain_ids",
+            "in": "query",
+            "description": "Comma separated list of chain ids to get activity for",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "The offset to paginate through result sets. This is a cursor being passed from the previous response.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of activity items to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "nullable": true,
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponse"
+                },
+                "example": {
+                  "activity": [
+                    {
+                      "chain_id": 1,
+                      "transaction_hash": "0xc8d44a0969e3877e941e5bcfcd0296cf694b6ffb62815d3e7df3f6004febf69b",
+                      "type": "transfer",
+                      "asset_type": "erc20",
+                      "token_address": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+                      "from": "0xe00d482dbe7d8495aade979b8ef83e09b180d14a",
+                      "to": "0xf7cd385cb9a442358b892b14301f6310e57cc5c9",
+                      "value": "0x570d71c6b72b91d750",
+                      "metadata": {
+                        "symbol": "GRT",
+                        "decimals": 18,
+                        "description": "Sent 1605.8355082976045 GRT to 0xf7cd385cb9a442358b892b14301f6310e57cc5c9"
+                      }
+                    },
+                    {
+                      "chain_id": 1,
+                      "transaction_hash": "0x99a9c44c5b19f80b4f31a619810612a2694d2cd3365d3809b602aec8fc8ccb9c",
+                      "type": "transfer",
+                      "asset_type": "erc721",
+                      "token_address": "0x0baeccd651cf4692a8790bcc4f606e79bf7a3b1c",
+                      "from": "0x68b80746e4f4e55e988f67b820fff189aca14dbc",
+                      "to": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+                      "id": "0x1aa0",
+                      "description": "Received ERC721 token #6816 (0x0baeccd651cf4692a8790bcc4f606e79bf7a3b1c) from 0x68b80746e4f4e55e988f67b820fff189aca14dbc"
+                    }
+                  ],
+                  "next_offset": "KgAAAAAAAAAweGQ4ZGE2YmYyNjk2NGFmOWQ3ZWVkOWUwM2U1MzQxNWQzN2FhOTYwNDVAEUxneCwGAAUhAAAAAAAAvcOEAQAAAAAAAAAAAAAAACoAAAAAAAAAAAAAAAAAAAA"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request - The request could not be understood by the server due to malformed data"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error - A generic error occurred on the server"
+          }
+        }
+      }
+    },
     "/echo/beta/balances/svm/{address}": {
       "get": {
         "tags": [
@@ -957,6 +1078,110 @@
   },
   "components": {
     "schemas": {
+      "ActivityItem": {
+        "type": "object",
+        "required": [
+          "chain_id",
+          "transaction_hash",
+          "type"
+        ],
+        "properties": {
+          "chain_id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "transaction_hash": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["transfer", "call", "mint"]
+          },
+          "asset_type": {
+            "type": "string",
+            "enum": ["native", "erc20", "erc721"],
+            "nullable": true
+          },
+          "token_address": {
+            "type": "string",
+            "nullable": true
+          },
+          "from": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "Token ID for ERC721 transfers",
+            "nullable": true
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "symbol": {
+                "type": "string",
+                "nullable": true
+              },
+              "decimals": {
+                "type": "integer",
+                "nullable": true
+              },
+              "description": {
+                "type": "string"
+              }
+            }
+          },
+          "function": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "inputs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "ActivityResponse": {
+        "type": "object",
+        "required": [
+          "activity"
+        ],
+        "properties": {
+          "activity": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ActivityItem"
+            }
+          },
+          "next_offset": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
       "BalanceData": {
         "type": "object",
         "required": [

--- a/mint.json
+++ b/mint.json
@@ -2115,7 +2115,8 @@
             "echo/evm/balances",
             "echo/evm/balances-chains",
             "echo/evm/transactions",
-            "echo/evm/transactions-chains"
+            "echo/evm/transactions-chains",
+            "echo/evm/activity"
           ]
         },
         {


### PR DESCRIPTION
Adding documentation for our activity endpoint. A bit hairy because a) the endpoint is only in dev and b) @markushauge and @2xic don't have the auto openapi spec generation enabled for that endpoint at the moment so I decided to just generate it with an ai assistant. Probably not perfect but works pretty well. We can switch over to the prod endpoint and the real openapi spec as soon as they're ready.