### PR TITLE
Add policy for bug bounty variations and bypasses

### DIFF
--- a/web-app/bug-bounty.mdx
+++ b/web-app/bug-bounty.mdx
@@ -38,6 +38,14 @@ Bounty sizes are determined at Dune's sole discretion. We consider the severity 
 ### Duplicate Submissions Policy
 We value all security research, but we do not provide rewards for submissions that cover known issues already reported by other researchers or internally identified by our team. If your report is a duplicate, we will notify you of the status and appreciate your effort, but no bounty will be issued.
 
+### Variations and Bypasses of Previously Reported Issues
+If you discover a bypass or a variation of a previously reported vulnerability, this will typically be considered part of the same issue and not eligible for an additional full bounty. This applies especially to cases where:
+- A fix for a previously reported issue was incomplete or could be bypassed
+- The vulnerability uses a similar technique with minor variations
+- The vulnerability affects the same endpoint or feature
+
+We encourage researchers to thoroughly test our fixes and report bypasses, but these will generally be bundled with the original report for bounty considerations. In some cases, at our discretion, we may offer a smaller reward for significant bypasses that require substantial new techniques.
+
 ### Misuse of Stolen Credentials
 We value all security research, but issues stemming from stolen or compromised credentials (e.g., through malware or phishing attacks on user browsers) do not qualify as vulnerabilities in our systems and are therefore not eligible for a bounty.
 


### PR DESCRIPTION
## Summary
- Add new section to bug bounty documentation to address variations and bypasses of previously reported issues
- Clarifies that bypasses of previous fixes will be considered part of the same issue
- Defines criteria for what constitutes a variation or bypass
- Establishes policy for bundling similar reports into one bounty consideration
