### PR TITLE
Fix HTTP methods in CRUD endpoint examples

### DIFF
--- a/api-reference/crud/endpoint/archive.mdx
+++ b/api-reference/crud/endpoint/archive.mdx
@@ -10,7 +10,7 @@ In Dune context, delete action is replaced by archive as deletion of queries is 
 <RequestExample>
 
 ```bash cURL
-curl --request GET \
+curl --request POST \
   --url https://api.dune.com/api/v1/query/{queryId}/archive \
   --header 'X-DUNE-API-KEY: <x-dune-api-key>'
 ```
@@ -33,14 +33,14 @@ url = "https://api.dune.com/api/v1/query/{queryId}/archive"
 
 headers = {"X-DUNE-API-KEY": "<x-dune-api-key>"}
 
-response = requests.request("GET", url, headers=headers)
+response = requests.request("POST", url, headers=headers)
 
 print(response.text)
 
 ```
 
 ```javascript JavaScript
-const options = {method: 'GET', headers: {'X-DUNE-API-KEY': '<x-dune-api-key>'}};
+const options = {method: 'POST', headers: {'X-DUNE-API-KEY': '<x-dune-api-key>'}};
 
 fetch('https://api.dune.com/api/v1/query/{queryId}/archive', options)
   .then(response => response.json())
@@ -61,7 +61,7 @@ func main() {
 
 	url := "https://api.dune.com/api/v1/query/{queryId}/archive"
 
-	req, _ := http.NewRequest("GET", url, nil)
+	req, _ := http.NewRequest("POST", url, nil)
 
 	req.Header.Add("X-DUNE-API-KEY", "<x-dune-api-key>")
 
@@ -88,7 +88,7 @@ curl_setopt_array($curl, [
   CURLOPT_MAXREDIRS => 10,
   CURLOPT_TIMEOUT => 30,
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => "GET",
+  CURLOPT_CUSTOMREQUEST => "POST",
   CURLOPT_HTTPHEADER => [
     "X-DUNE-API-KEY: <x-dune-api-key>"
   ],
@@ -107,7 +107,7 @@ if ($err) {
 ```
 
 ```java Java
-HttpResponse<String> response = Unirest.get("https://api.dune.com/api/v1/query/{queryId}/archive")
+HttpResponse<String> response = Unirest.post("https://api.dune.com/api/v1/query/{queryId}/archive")
   .header("X-DUNE-API-KEY", "<x-dune-api-key>")
   .asString();
 ```

--- a/api-reference/crud/endpoint/private.mdx
+++ b/api-reference/crud/endpoint/private.mdx
@@ -6,7 +6,7 @@ openapi: 'POST /v1/query/{queryId}/private'
 <RequestExample>
 
 ```bash cURL
-curl --request GET \
+curl --request POST \
   --url https://api.dune.com/api/v1/query/{queryId}/private \
   --header 'X-DUNE-API-KEY: <x-dune-api-key>'
 ```
@@ -29,14 +29,14 @@ url = "https://api.dune.com/api/v1/query/{queryId}/private"
 
 headers = {"X-DUNE-API-KEY": "<x-dune-api-key>"}
 
-response = requests.request("GET", url, headers=headers)
+response = requests.request("POST", url, headers=headers)
 
 print(response.text)
 
 ```
 
 ```javascript JavaScript
-const options = {method: 'GET', headers: {'X-DUNE-API-KEY': '<x-dune-api-key>'}};
+const options = {method: 'POST', headers: {'X-DUNE-API-KEY': '<x-dune-api-key>'}};
 
 fetch('https://api.dune.com/api/v1/query/{queryId}/private', options)
   .then(response => response.json())
@@ -57,7 +57,7 @@ func main() {
 
 	url := "https://api.dune.com/api/v1/query/{queryId}/private"
 
-	req, _ := http.NewRequest("GET", url, nil)
+	req, _ := http.NewRequest("POST", url, nil)
 
 	req.Header.Add("X-DUNE-API-KEY", "<x-dune-api-key>")
 
@@ -84,7 +84,7 @@ curl_setopt_array($curl, [
   CURLOPT_MAXREDIRS => 10,
   CURLOPT_TIMEOUT => 30,
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => "GET",
+  CURLOPT_CUSTOMREQUEST => "POST",
   CURLOPT_HTTPHEADER => [
     "X-DUNE-API-KEY: <x-dune-api-key>"
   ],
@@ -103,7 +103,7 @@ if ($err) {
 ```
 
 ```java Java
-HttpResponse<String> response = Unirest.get("https://api.dune.com/api/v1/query/{queryId}/private")
+HttpResponse<String> response = Unirest.post("https://api.dune.com/api/v1/query/{queryId}/private")
   .header("X-DUNE-API-KEY", "<x-dune-api-key>")
   .asString();
 ```

--- a/api-reference/crud/endpoint/unarchive.mdx
+++ b/api-reference/crud/endpoint/unarchive.mdx
@@ -10,7 +10,7 @@ In Dune context, delete action is replaced by archive as deletion of queries is 
 <RequestExample>
 
 ```bash cURL
-curl --request GET \
+curl --request POST \
   --url https://api.dune.com/api/v1/query/{queryId}/unarchive \
   --header 'X-DUNE-API-KEY: <x-dune-api-key>'
 ```
@@ -33,14 +33,14 @@ url = "https://api.dune.com/api/v1/query/{queryId}/unarchive"
 
 headers = {"X-DUNE-API-KEY": "<x-dune-api-key>"}
 
-response = requests.request("GET", url, headers=headers)
+response = requests.request("POST", url, headers=headers)
 
 print(response.text)
 
 ```
 
 ```javascript JavaScript
-const options = {method: 'GET', headers: {'X-DUNE-API-KEY': '<x-dune-api-key>'}};
+const options = {method: 'POST', headers: {'X-DUNE-API-KEY': '<x-dune-api-key>'}};
 
 fetch('https://api.dune.com/api/v1/query/{queryId}/unarchive', options)
   .then(response => response.json())
@@ -61,7 +61,7 @@ func main() {
 
 	url := "https://api.dune.com/api/v1/query/{queryId}/unarchive"
 
-	req, _ := http.NewRequest("GET", url, nil)
+	req, _ := http.NewRequest("POST", url, nil)
 
 	req.Header.Add("X-DUNE-API-KEY", "<x-dune-api-key>")
 
@@ -88,7 +88,7 @@ curl_setopt_array($curl, [
   CURLOPT_MAXREDIRS => 10,
   CURLOPT_TIMEOUT => 30,
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => "GET",
+  CURLOPT_CUSTOMREQUEST => "POST",
   CURLOPT_HTTPHEADER => [
     "X-DUNE-API-KEY: <x-dune-api-key>"
   ],
@@ -107,7 +107,7 @@ if ($err) {
 ```
 
 ```java Java
-HttpResponse<String> response = Unirest.get("https://api.dune.com/api/v1/query/{queryId}/unarchive")
+HttpResponse<String> response = Unirest.post("https://api.dune.com/api/v1/query/{queryId}/unarchive")
   .header("X-DUNE-API-KEY", "<x-dune-api-key>")
   .asString();
 ```

--- a/api-reference/crud/endpoint/unprivate.mdx
+++ b/api-reference/crud/endpoint/unprivate.mdx
@@ -6,7 +6,7 @@ openapi: 'POST /v1/query/{queryId}/unprivate'
 <RequestExample>
 
 ```bash cURL
-curl --request GET \
+curl --request POST \
   --url https://api.dune.com/api/v1/query/{queryId}/unprivate \
   --header 'X-DUNE-API-KEY: <x-dune-api-key>'
 ```
@@ -29,14 +29,14 @@ url = "https://api.dune.com/api/v1/query/{queryId}/unprivate"
 
 headers = {"X-DUNE-API-KEY": "<x-dune-api-key>"}
 
-response = requests.request("GET", url, headers=headers)
+response = requests.request("POST", url, headers=headers)
 
 print(response.text)
 
 ```
 
 ```javascript JavaScript
-const options = {method: 'GET', headers: {'X-DUNE-API-KEY': '<x-dune-api-key>'}};
+const options = {method: 'POST', headers: {'X-DUNE-API-KEY': '<x-dune-api-key>'}};
 
 fetch('https://api.dune.com/api/v1/query/{queryId}/unprivate', options)
   .then(response => response.json())
@@ -57,7 +57,7 @@ func main() {
 
 	url := "https://api.dune.com/api/v1/query/{queryId}/unprivate"
 
-	req, _ := http.NewRequest("GET", url, nil)
+	req, _ := http.NewRequest("POST", url, nil)
 
 	req.Header.Add("X-DUNE-API-KEY", "<x-dune-api-key>")
 
@@ -84,7 +84,7 @@ curl_setopt_array($curl, [
   CURLOPT_MAXREDIRS => 10,
   CURLOPT_TIMEOUT => 30,
   CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-  CURLOPT_CUSTOMREQUEST => "GET",
+  CURLOPT_CUSTOMREQUEST => "POST",
   CURLOPT_HTTPHEADER => [
     "X-DUNE-API-KEY: <x-dune-api-key>"
   ],
@@ -103,7 +103,7 @@ if ($err) {
 ```
 
 ```java Java
-HttpResponse<String> response = Unirest.get("https://api.dune.com/api/v1/query/{queryId}/unprivate")
+HttpResponse<String> response = Unirest.post("https://api.dune.com/api/v1/query/{queryId}/unprivate")
   .header("X-DUNE-API-KEY", "<x-dune-api-key>")
   .asString();
 ```


### PR DESCRIPTION
Correct the HTTP method from GET to POST in various examples in the `archive.mdx`, `private.mdx`, `unarchive.mdx`, and `unprivate.mdx` files.

* **archive.mdx**
  - Change HTTP method from GET to POST in cURL, Python, JavaScript, Go, PHP, and Java examples.

* **private.mdx**
  - Change HTTP method from GET to POST in cURL, Python, JavaScript, Go, PHP, and Java examples.

* **unarchive.mdx**
  - Change HTTP method from GET to POST in cURL, Python, JavaScript, Go, PHP, and Java examples.

* **unprivate.mdx**
  - Change HTTP method from GET to POST in cURL, Python, JavaScript, Go, PHP, and Java examples.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/duneanalytics/dune-docs/pull/612?shareId=bc07299c-dbfc-4cee-9e50-8f1a64f96c42).