### PR TITLE
Move sim documentation to dune-docs

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -2465,6 +2465,59 @@
     {
       "group": "",
       "pages": ["catalyst/overview"]
+    },
+    {
+      "group": "sim",
+      "pages": [
+        "sim/index",
+        {
+          "group": "Getting Started",
+          "pages": [
+            "sim/getting-started/account-setup",
+            "sim/getting-started/querying-data",
+            "sim/getting-started/hello-lambda",
+            "sim/getting-started/a-simple-api"
+          ]
+        },
+        {
+          "group": "Example Canvases",
+          "pages": [
+            "sim/example-canvases/explorer-homepage",
+            "sim/example-canvases/tracking-erc721-transfers",
+            "sim/example-canvases/partydao-crowdfund-statuses",
+            "sim/example-canvases/flash-swaps-on-uniswapv2",
+            "sim/example-canvases/monitor-and-activate-makers-esm",
+            "sim/example-canvases/on-chain-prices",
+            "sim/example-canvases/powering-bots-with-webhooks"
+          ]
+        },
+        {
+          "group": "Canvas Components",
+          "pages": [
+            "sim/canvas-components/api",
+            "sim/canvas-components/comment",
+            "sim/canvas-components/data-source",
+            "sim/canvas-components/evm-lambda",
+            "sim/canvas-components/external-trigger",
+            "sim/canvas-components/patch",
+            "sim/canvas-components/persistence",
+            "sim/canvas-components/schema-mirror",
+            "sim/canvas-components/schema",
+            "sim/canvas-components/webhook"
+          ]
+        },
+        {
+          "group": "More Details",
+          "pages": [
+            "sim/more-details/custom-types",
+            "sim/more-details/global-counter",
+            "sim/more-details/hook-ctx-and-simfunctions",
+            "sim/more-details/querying-and-data-types-faq",
+            "sim/more-details/storage-hooks",
+            "sim/reference/simfunctions/index"
+          ]
+        }
+      ]
     }
   ],
   "feedback": {

--- a/sim/example-canvases/explorer-homepage.mdx
+++ b/sim/example-canvases/explorer-homepage.mdx
@@ -1,0 +1,85 @@
+---
+title: Explorer Homepage
+description: Let's explore how we built the sim Explorer homepage with sim
+---
+
+## Goal
+
+Our old homepage for [sim Explorer / evm.storage](https://explorer.sim.io/) was a search bar with a static list of three contracts that you could click into. We wanted to make a new one with sim that was more engaging and dynamic, and decided on adding modules for recent blocks, active contracts, and latest transactions. Here's the new design:
+
+<img 
+  src="https://files.readme.io/4cd96e7-image.png" 
+  alt="Explorer homepage design" 
+  className="border" 
+/>
+
+## Canvas
+
+<iframe 
+  src="https://studio.sim.io/embed/520c88e1-6b30-4617-98fa-a7e3ef646d60" 
+  title="Explorer homepage canvas" 
+  width="100%" 
+  height="400px" 
+  frameborder="0">
+</iframe>
+
+## APIs
+
+### Recent blocks
+
+The recent blocks API uses the [@sim.blocks](/sim/reference/core-tables/blocks) core table to pull the most recent ten blocks. The query includes CTEs to apply the latest ENS resolution for each coinbase address. We also use whether the address has been the sender on any transactions as a simple heuristic to classify it as an EOA as opposed to a contract.
+
+### Active contracts
+
+The active contracts API sums calls and transactions in blocks across the last hour and the hour before that for every contract, then it sorts by call counts descending and returns the ten most active contracts. This table uses the `@org.contract_call_counts_block` table built in this canvas and described below.
+
+### Latest transactions
+
+The latest transactions API uses the @sim.ethereum\_transactions core table to pull the most recent transactions. Like we did for coinbase in the recent blocks API, we add in ENS names and add identifiers for whether the from or to addresses are EOAs.
+
+## Data pipeline
+
+To build the `@org.contract_call_counts_block` table, we built a simple data pipeline that runs at the tip for Ethereum and Base. The Lambda hooks on each txn/call. Ignoring precompiles, if the call recipient is seen for the first time, it's added to the `activeContracts` array. We increment the `call_counts` value for that address by one. And, if it's an external transaction, i.e., `call_depth == 0`, we also increment the `txn_counts` variable.
+
+```solidity
+function postTransaction() public {
+    CallContext storage ctx = getCallContext();
+    // ignore precompiles
+    if (uint160(ctx.txn.to()) <= 9) {
+    return;
+    }
+    if (!isActive[ctx.txn.to()]) {
+        activeContracts.push(ctx.txn.to());
+        isActive[ctx.txn.to()] = true;
+    }
+    call_counts[ctx.txn.to()]++;
+    if (ctx.call_depth == 0) {
+        txn_counts[ctx.txn.to()]++;
+    }
+}
+```
+
+Because standard EVM Lambda state is reset between blocks, `activeContracts`, `call_counts`, and `txn_counts` are stateful within the block and adjust on each transaction. At the end of the block, we simply iterate over the `activeContracts` array and emit the counts and some other data for each contract:
+
+```solidity
+function postBlock() public {
+    for (uint256 i = activeContracts.length; i > 0; i--) {
+        simEmitToSchema_call_counts(
+            SchemaCall_countsColumns({
+                chain_id: uint64(block.chainid),
+                block_timestamp: uint64(block.timestamp),
+                block_number: uint64(block.number),
+                contract_address: activeContracts[i-1],
+                name: getName(activeContracts[i-1]),
+                symbol: getSymbol(activeContracts[i-1]),
+                call_count: call_counts[activeContracts[i-1]],
+                txn_count: txn_counts[activeContracts[i-1]]
+            })
+        );
+    }
+}
+```
+
+<Note>
+You'll notice we also define `getName` and `getSymbol` functions. These just allow us to grab the name and symbol on contracts that expose them without causing reversions when trying to fetch them from contracts that don't.
+</Note>

--- a/sim/example-canvases/flash-swaps-on-uniswapv2.mdx
+++ b/sim/example-canvases/flash-swaps-on-uniswapv2.mdx
@@ -1,0 +1,143 @@
+---
+title: Flash Swaps on Uniswap V2
+description: Let's track flash swaps on Uniswap V2
+---
+
+## Goal
+
+A regular Uniswap V2 swap involves an exchange of one token for another within a liquidity pool (LP). Uniswap V2 pioneered [flash swaps](https://docs.uniswap.org/contracts/v2/guides/smart-contract-integration/using-flash-swaps), in which a user can withdraw as much as they want of any token in a liquidity pool instantly with zero upfront cost. By transaction end, the user must: 1) Return the withdrawn tokens themselves OR 2) Return an equivalent amount in other tokens. In either case, there's also an LP fee. If the conditions above are not met, the transaction fails, and the entire swap is reverted.
+
+Flash swaps allow users of the protocol to create callbacks that will act upon initiating a swap via some `UniswapV2Pair` pool. These callbacks are predefined in contracts that implement the `IUniswapV2Callee` interface. In this example, we will create a canvas that tracks and provides data on flash swaps.
+
+<Note>
+If you want to skip to the end, here's [the canvas](https://studio.sim.io/canvases/87c44139-6d16-4522-8a32-be059e7c0c4c) that already has everything built.
+</Note>
+
+<iframe 
+  src="https://studio.sim.io/embed/87c44139-6d16-4522-8a32-be059e7c0c4c" 
+  title="Flash Swaps Canvas" 
+  width="100%" 
+  height="500px" 
+  frameborder="0">
+</iframe>
+
+## Setting up the pipeline
+
+### Adding components
+
+1. Start by adding a *Data source* component. We want our pipeline to run at the tip, so we leave *To* blank and set *From* to the `UniswapV2Factory`'s deployment block (10000835). 
+
+2. Add an *EVM Lambda* component and connect it to the right handle of the data source. For now, leave it as is. We'll come back to it in a bit.
+
+3. Add a *Schema* and name it `uniswap_v2_flash_swaps`. Draw a connection from the lambda to the schema component and populate the schema with some important data we want to persist about each flash swap, as follows:
+
+| Name                   | Type    |
+| ---------------------- | ------- |
+| txn\_hash              | bytes32 |
+| block\_number          | uint64  |
+| initiator              | address |
+| uniswapV2Callee        | address |
+| token0                 | address |
+| token1                 | address |
+| pair                   | address |
+| is\_official\_v2\_pair | bool    |
+| pair\_factory          | address |
+
+4. Add a *Persistence* component and connect it to the *Schema* component. Save the schema and set the persistence.
+
+5. Finally, add an *API* component that we will use to query the data in our table. Leave the query empty for now--we'll come back to it later.
+
+<Tip>
+You're all set! 🎉
+</Tip>
+
+### Writing the code
+
+We want to hook on all calls to the `uniswapV2Call(address,uint256,uint256,bytes)` function of all contracts. That means we need to target a specific ABI. For that we can use the `Input ABI Manually` option in our *EVM Lambda* component. This will hook on all contracts whose ABI include the inputted ABI. Let's input the JSON formatted ABI for our `IUniswapV2Callee` interface:
+
+```json
+[
+    {
+        "inputs":
+        [
+            {
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount0",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amount1",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "uniswapV2Call",
+        "outputs":
+        [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]
+```
+
+Now we can add a *post* hook on the `uniswapV2Call` method and add a callback:
+
+```solidity
+function handleFlashSwap() public {
+    handleFlashSwapContext storage ctx = getHandleFlashSwapContext();
+    address token0 = IUniswapV2Pair(ctx.txn.from()).token0(); // fetch the address of token0
+    address token1 = IUniswapV2Pair(ctx.txn.from()).token1(); // fetch the address of token1
+    address factory = IUniswapV2Pair(ctx.txn.from()).factory(); // fetch the factory of the pair
+    simEmitToSchema_uniswap_v2_flash_swaps(
+        SchemaUniswap_v2_flash_swapsColumns({
+            txn_hash: ctx.txn.hash(),
+            block_number: uint64(block.number),
+            initiator: ctx.inputs.sender,
+            uniswapV2Callee: ctx.txn.to(),
+            token0: token0,
+            token1: token1,
+            pair: ctx.txn.from(),
+            is_official_v2_pair: ctx.txn.from() == IUniswapV2Factory(FACTORY_V2).getPair(token0, token1),
+            pair_factory: factory
+        })
+    );
+}
+```
+
+<Note>
+Note that we want to verify if the call made was initiated by an official `UniswapV2Pair` contract. For that, we call the `UniswapV2Factory` and verify that the contract calling the callee is indeed the pair for `token0` and `token1`, as registered in the factory.
+</Note>
+
+### Execution
+
+You can test the execution within the code editor using the range `19000000` to `19000010`. You should see some results. Then we hit the play button on the execution edge to launch the full tip and backfill jobs.
+
+### Setting up the API
+
+If we want to do some analysis, we could open the query editor and write many SQL queries against our created data. But let's just go ahead and build an API that will serve the data for the N most recent flash swaps for a given LP. Go to the *API* component and input the following query:
+
+```sql
+select * from @org.uniswap_v2_flash_swaps
+where pair = $pool
+order by block_number desc
+limit $limit
+```
+
+The pool parameter should be set to `address` and the limit should be set to `uint32`. If you want, you could specify default values of `0xf848e97469538830b0b147152524184a255b9106` and `1` respectively. Then test and set the API, and it's ready to be used.
+
+## Key takeaways
+
+<Tip>
+1. Targeting custom ABIs is useful when we want to target a specific family of contracts that only have a limited set of functions/logs in common (such as `IUniswapV2Callee` contracts). sim makes this easy!
+2. Making calls to arbitrary contracts from within sim callbacks is easy and allows us to compute anything we need to persist.
+</Tip>

--- a/sim/example-canvases/monitor-and-activate-makers-esm.mdx
+++ b/sim/example-canvases/monitor-and-activate-makers-esm.mdx
@@ -1,0 +1,129 @@
+---
+title: Monitor and Activate Maker's ESM
+description: We build a canvas that can be used to automatically shutdown Maker during a crisis
+---
+
+## Goal
+
+Maker is a popular lending protocol that allows its governance token's ([MKR](https://docs.makerdao.com/smart-contract-modules/mkr-module)) holders to decide when it is unsafe for the protocol to operate and, if necessary, shutdown all of its modules.
+
+In order to shutdown the protocol, Maker deployed an [Emergency Shutdown Module (ESM)](https://docs.makerdao.com/smart-contract-modules/shutdown/emergency-shutdown-module). Holders of MKR can deposit their tokens at any time. Once the amount of deposited tokens reaches a threshold, the emergency kill-switch can be used by any caller to the contract's `fire()` method. It shuts down all Maker contracts. 
+
+In this example, we show how we can monitor the amount of deposited tokens and send reports via a webhook to a server that will automatically call `fire()` when the threshold is reached.
+
+<Note>
+If you want to skip to the end, here's [the canvas](https://studio.sim.io/canvases/828f9285-0bab-47bf-bd7d-ca4f9580abf3) that already has everything built:
+</Note>
+
+<iframe 
+  src="https://studio.sim.io/embed/828f9285-0bab-47bf-bd7d-ca4f9580abf3" 
+  title="Maker ESM Canvas" 
+  width="100%" 
+  height="400px" 
+  frameborder="0">
+</iframe>
+
+## Before you start
+
+<Warning>
+You need a place to run your server that receives the webhooks and calls `fire()` if necessary. We are using [Heroku](https://heroku.com), but you can use any provider that can receive webhooks.
+</Warning>
+
+## Setting up the pipeline
+
+### Adding components
+
+1. Start by adding a *Data source* component. We want our pipeline to run at the tip, so we leave *To* blank and set *From* to the ESM's deployment block (14125857). 
+
+2. Add an *EVM Lambda* component and connect it to the right handle of the data source. For now, leave it as is. We'll come back to it in a bit.
+
+3. Then we add a *Schema* with the data we need for our webhook. Let's call it `sum_reached`. We want our webhook to receive reports for every change in `Sum`(the amount of deposited MKR tokens) and we only want the webhook to call `fire()` when `Sum > min`. Draw a connection from the lambda to the schema component and populate the schema as follows:
+
+| Name               | Type    |
+| ------------------ | ------- |
+| sum                | uint256 |
+| threshold\_reached | bool    |
+
+4. Finally we add a *Webhook* component. Point it to the server instance you have running and set a rate limit if you want. Then connect the schema to the webhook component.
+
+<Tip>
+You're all set! 🎉
+</Tip>
+
+### Writing the code
+
+We want to hook on all changes to `Sum`.
+
+1. Select `Address` for hook type and put the ESM address (`0x09e05ff6142f2f9de8b6b65855a1d56b6cfe4c58`) in the input. We'll use this [evm.storage](https://evm.storage/eth/19724666/0x09e05ff6142f2f9de8b6b65855a1d56b6cfe4c58/Sum#map) link to hook on just (post) on the `Sum` variable.
+
+2. In the callback, we simply call the `min()` function to get the threshold and emit a message to the `Schema` we created before. We could emit this message only in cases where the threshold is reached, but here we're emitting it in either case along with a flag representing whether the threshold is reached.
+
+```solidity
+function handleSumChange() public {
+    handleSumChangeContext storage ctx = getHandleSumChangeContext();
+    if (ctx.valueAfter >= IESM(ctx.txn.codeAddress).min()) {
+        simEmitToSchema_sum_reached(
+            ctx.valueAfter, // sum
+            true // reached
+        );
+    } else {
+        simEmitToSchema_sum_reached(
+            ctx.valueAfter, // sum
+            false // reached
+        );
+    }
+}
+```
+
+## A server to handle the webhooks
+
+When a webhook message reaches the server, we need to inspect the data and decide if we call `fire()` or not.
+
+1. We have a flask server running waiting for a request, we then post a transaction on-chain to the ESM contract if necessary. Here's the code:
+
+```python
+from flask import Flask, request, jsonify
+from web3 import Web3
+
+app = Flask(__name__)
+
+# Configure your Ethereum node provider
+# For example, using Infura:
+web3 = Web3(Web3.HTTPProvider('https://mainnet.infura.io/v3/YOUR_INFURA_PROJECT_ID'))
+
+# The address that will send the transactions
+from_address = web3.toChecksumAddress('your-wallet-address')
+private_key = 'your-private-key'
+
+# ABI and address for the smart contract
+contract_address = web3.toChecksumAddress('contract-address')
+# We can use a partial ABI that contains only the `fire()` function.
+contract_abi = json.loads('[{"inputs":[],"name":"fire","outputs":[],"stateMutability":"nonpayable","type":"function"}]')
+contract = web3.eth.contract(address=contract_address, abi=contract_abi)
+
+@app.route('/webhook', methods=['POST'])
+def webhook():
+    data = request.json
+    if data['threshold_reached']:
+      nonce = web3.eth.getTransactionCount(from_address)
+      txn_dict = contract.functions.fire().buildTransaction({
+          'chainId': 1,  # Mainnet chain ID
+          'gas': 2000000,
+          'gasPrice': web3.toWei('50', 'gwei'),
+          'nonce': nonce,
+      })
+      # Sign the transaction
+      signed_txn = web3.eth.account.signTransaction(txn_dict, private_key=private_key)
+      # Send the transaction
+      txn_receipt = web3.eth.sendRawTransaction(signed_txn.rawTransaction)
+      txn_hash = web3.toHex(txn_receipt)
+
+    return jsonify({'transaction_hash': txn_hash}), 200
+```
+
+## Key takeaways
+
+<Tip>
+1. Monitoring your protocol's contracts' state becomes an easy task when using sim's powerful storage hooks.
+2. You can use webhooks in order to send on-chain transactions and respond to events that happen in your protocol (liquidity of pools, balance of accounts, state variable changes, etc.)
+</Tip>

--- a/sim/example-canvases/on-chain-prices.mdx
+++ b/sim/example-canvases/on-chain-prices.mdx
@@ -1,0 +1,137 @@
+---
+title: On-Chain Prices
+description: Let's use Uniswap V2 to track on-chain prices
+---
+
+## Goal
+
+What's the price of ether? It's a central question to so many blockchain apps, but it's difficult to answer. It can be traded at different prices in different places, both off-chain and on-chain. Believers in efficient markets would hope arbitrage would align them, and, indeed, this was one of the earliest crypto arbitrage strategies. But there's enough complexity in pricing that many outsource it away to centralized third-party pricing APIs. That's a pity. 
+
+In this doc, we show you how to index your own prices using on-chain state. To do this, we'll track Uniswap V2 liquidity pools (LP). Each LP corresponds to a pair of tokens, and the price of one token in the pair relative to the other is a simple function of the ratio of the reserves. In tracking all pairs, we'll be able to express the spot price of any token relative to any other so long as an Uniswap V2 LP exists for the pair. [There are many](https://v2.info.uniswap.org/pairs)! You could even go further with multi-hop comparisons.
+
+Finally, we'll check our work against the Uniswap V2 LP for WETH and USDC to get a current price of ether in US dollars.
+
+<Note>
+If you want to skip to the end, here's [a canvas](https://studio.sim.io/canvases/8c54aaea-4cf2-4517-8843-6e1331763fd7) that already has everything built.
+</Note>
+
+## Set up the Lambda
+
+1. Add an EVM Lambda to the canvas. Under *Hook type* select *ABI* and then *Address* for selection type. Input: `0x3356c9A8f40F8E9C1d192A4347A76D18243fABC5`. This is a Uniswap V2 LP. Since we're using the ABI hook, we're hooking on all Uniswap V2 LPs. Select the `swap` function hook--don't confuse it for the `Swap` log hook--and add it as a *Post* hook with a callback named `postSwap`. We don't need an automatically generated schema here--we'll create our own.
+
+2. Click the + button next to schemas and create a new schema called `uniswap_v2_prices`. Add these fields:
+
+   | Name             | Type    |
+   | :--------------- | :------ |
+   | chain\_id        | uint64  |
+   | block\_number    | uint64  |
+   | block\_timestamp | uint64  |
+   | token0           | address |
+   | token0\_symbol   | string  |
+   | token0\_decimals | uint64  |
+   | token1           | address |
+   | token1\_symbol   | string  |
+   | token1\_decimals | uint64  |
+   | reserve0         | uint256 |
+   | reserve1         | uint256 |
+
+3. When you're done editing the schema, hit `Save`. Also add a *Block* hook with *Post* position and name the callback `postBlock`. No need for a new schema here.
+
+4. As part of our execution, we're going to call UniswapV2 LPs. To do that, we need the interface. Click + next to Interfaces on the left side bar and select address. Input the address for any Uniswap V2 LP (e.g., `0x3356c9A8f40F8E9C1d192A4347A76D18243fABC5`) and search. Once you've done this, you'll see the added interface both in the sidebar and the *Interface code* tab within the code editor. Rename the interface by replacing `I0x3356c9A8f40F8E9C1d192A4347A76D18243fABC5` with `IUniswapV2`.
+
+5. Now we need to write our Lambda code:
+
+```solidity
+contract UserProbe is BaseDeclarativeProbe {
+    address[] public poolsWithReservesUpdated;
+    mapping(address => bool) poolVisited;
+    
+    function postBlock() public {
+        for (uint256 i = poolsWithReservesUpdated.length; i > 0; i--) {
+            address pool = poolsWithReservesUpdated[i-1];
+            poolsWithReservesUpdated.pop();
+            delete poolVisited[pool];
+          
+            (uint112 reserve0, uint112 reserve1,) = IUniswapV2(pool).getReserves();
+          
+            address token0 = IUniswapV2(pool).token0();
+            string memory token0_symbol = IUniswapV2(token0).symbol();
+            uint8 token0_decimals = IUniswapV2(token0).decimals();
+          
+            address token1 = IUniswapV2(pool).token1();
+            string memory token1_symbol = IUniswapV2(token1).symbol();
+            uint8 token1_decimals = IUniswapV2(token1).decimals();
+            
+            simEmitToSchema_uniswap_v2_prices(SchemaUniswap_v2_pricesColumns({
+                chain_id: uint64(block.chainid),
+                block_number: uint64(block.number),
+                block_timestamp: uint64(block.timestamp),
+                token0: token0,
+                token0_symbol: token0_symbol,
+                token0_decimals: uint64(token0_decimals),
+                token1: token1,
+                token1_symbol: token1_symbol,
+                token1_decimals: uint64(token1_decimals),
+                reserve0: reserve0,
+                reserve1: reserve1
+            }));
+        }
+    }
+
+    function postSwap() public {
+        postSwapContext storage ctx = getPostSwapContext();
+        address pool = ctx.txn.to();
+        if (!poolVisited[pool]) {
+            poolsWithReservesUpdated.push(pool);
+            poolVisited[pool] = true;
+        }
+    }
+}
+```
+
+6. Test your code with the *Test* button at the top-right of the IDE. Try 17000000 to 17000010
+
+## Build the pipeline
+
+1. Close the IDE. Click on the left handle of the Lambda component to add a `Data source`. If you wanted all the data, you would set *From* to 10000835, as this is when Uniswap V2 was first deployed on Ethereum. If you're just creating this canvas for learning, set the *From* to some block a few thousand blocks before the current tip block as it'll compute faster and reduce load on our systems.
+
+2. Leave the *To* block blank as we'll let our code catch up to the tip and then continue to execute.
+
+3. Click on the right handle of the Schema component to add a `Persistence`. Name the persistence `uniswap_v2_prices` and set it.
+
+4. Hit the play button on the execution edge. The code will start executing at the tip and backfilling from the `From` block. You can see its status by mousing over the `(?)`.
+
+## Querying the data
+
+Let's query the data! Uniswap V2 LPs work with ERC20 tokens. Neither ether nor USD are natively ERC20 tokens, of course, but each has an ERC20 pegged (in various ways) to it: [Wrapped Ether](https://evm.storage/eth/latest/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2) and [USDC](https://evm.storage/eth/latest/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48#map), respectively. To get the latest price of Ether, all we need to do is find the latest reserve ratio, normalizing for their differing decimals (WETH has 18, whereas USDC has 6).
+
+```sql
+select block_number,
+       token0_symbol,
+       token1_symbol,
+       (1.0 * reserve0 / POWER(10, token0_decimals)) / (1.0 * reserve1 / POWER(10, token1_decimals))
+from $org.uniswap_v2_prices
+where token0 = lower('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48')
+and token1 = lower('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2')
+order by block_number desc
+limit 1
+```
+
+## Key takeaways
+
+<Tip>
+1. With block hooks and variable declaration, it's easy to perform some execution at the beginning or end of every block.
+2. You can condition the execution in one callback with state from another, as we did here with the postSwap callback.
+3. With interfaces, it's easy to interact with contracts directly within your execution.
+4. On-chain prices are easy!
+</Tip>
+
+## While you're here
+
+You could quite easily iterate this canvas further into a full backend for a pricing dApp:
+
+1. Query other prices.
+2. Query a history of price changes for a specific pair.
+3. Make prices queryable via an API.
+4. Push out price updates via a webhook.
+5. Add coverage for Uniswap V3 and/or other protocols.

--- a/sim/example-canvases/partydao-crowdfund-statuses.mdx
+++ b/sim/example-canvases/partydao-crowdfund-statuses.mdx
@@ -1,0 +1,141 @@
+---
+title: PartyDAO Crowdfund Statuses
+description: We create one leaderboard of PartyDAO Crowdfunds and another of contributors within a crowdfund
+---
+
+## Goal
+
+Party is a protocol that allows users to start a "crowdfund," a group that collaborates and contributes (Ether) in order to achieve a certain goal, such as buying an NFT.
+
+Anyone can join a crowdfund by contributing Ether to the contract so long as the maximum amount allowed to be contributed to the fund hasn't been reached yet. Once the minimum amount contributed has been reached, the owner of the fund can execute the purpose of that fund, i.e., starting an ERC20 token or buying an NFT.
+
+In the following example, we build one API that gives us a leaderboard of contributors for a specific crowdfund as well as another API that gives us a leaderboard of crowdfunds, ordered by total contributions.
+
+<Note>
+If you want to skip to the end, here's [the canvas](https://studio.sim.io/canvases/2025e571-f58e-464a-a6fc-2b120e96b91c) that already has everything built.
+</Note>
+
+<iframe 
+  src="https://studio.sim.io/embed/2025e571-f58e-464a-a6fc-2b120e96b91c" 
+  title="PartyDAO Crowdfund Canvas" 
+  width="100%" 
+  height="400px" 
+  frameborder="0">
+</iframe>
+
+## Set up the Lambda
+
+1. Add an EVM Lambda to the canvas. Under *Hook type* select *ABI* and the input via address: `0xbda25a6e707be3887ee83e92203a5f6fbcc7775a`. This is an InitialETHCrowdfund contract. Since we're using the ABI hook, we're hooking on all contracts that implement this interface. Select the `Contributed` log hook and add it as a *Post* hook with a callback named `handleContribution`. Toggle on the `Generate schema` feature as it'll give us a good template.
+
+2. A schema will be automatically generated. Click the menu next to the schema and select `Edit`. Add these additional fields to the auto-generated schema:
+
+   | Name                 | Type    |
+   | -------------------- | ------- |
+   | global\_counter      | uint256 |
+   | block\_number        | uint64  |
+   | crowdfund            | address |
+   | party\_name          | string  |
+   | contributor          | address |
+   | amount               | uint256 |
+   | min\_required        | uint256 |
+   | max\_required        | uint256 |
+   | total\_contributions | uint256 |
+   | passed\_min          | bool    |
+
+3. Open the *Interfaces* sidebar and input the address for an InitialETHCrowdfund contract (`0xbda25a6e707be3887ee83e92203a5f6fbcc7775a`) and search. Once you've done this, you'll see the added interface both in the sidebar and the *Interface code* tab within the code editor. Rename the interface by replacing `I0xbda25a6e707be3887ee83e92203a5f6fbcc7775a` with `IInitialETHCrowdfund`.
+
+4. When you're done editing the schema, hit `Save`. Now we need to write our Lambda code:
+
+```solidity
+contract UserProbe is BaseDeclarativeProbe {
+    function handleContribution() public {
+        handleContributionContext storage ctx = getHandleContributionContext();
+        address cfProxy = simLogAddress();
+        uint96 min_req = IInitialETHCrowdfund(cfProxy).minTotalContributions();
+        uint96 max_req = IInitialETHCrowdfund(cfProxy).maxTotalContributions();
+        uint96 total_contributions = IInitialETHCrowdfund(cfProxy).totalContributions();
+        address party = IInitialETHCrowdfund(cfProxy).party();
+        string memory party_name = IParty(party).name();
+        
+        simEmitToSchema_crowdfund_contributions(SchemaCrowdfund_contributionsColumns({
+            global_counter: simGlobalCounter(),
+            block_number: uint64(block.number),
+            crowdfund: cfProxy,
+            party_name: party_name,
+            contributor: ctx.contributor,
+            amount: ctx.amount,
+            min_required: min_req,
+            max_required: max_req,
+            total_contributions: total_contributions + ctx.amount,
+            passed_min: total_contributions + ctx.amount >= min_req
+        }));
+    }
+}
+```
+
+<Warning>
+Three important notes:
+
+1. We use the `simGlobalCounter` to emit a unique identifier for each contribution event. Read more about it [here](/sim/more-details/global-counter)!
+
+2. Since Crowdfund contracts are proxies deployed by the factory and pointing to the same implementation contract, we use the `simLogAddress` function to get the address of the proxy itself to get proper values for the methods we call on the crowdfund contract.
+
+3. When targeting contracts by address, just like we did here, we get an automatically generated interface that is named after the address we've targeted. It can be renamed in the `Interfaces` tab for convenience to any name you find fit - in our case we've renamed it after the interface of the contracts we're targeting - `IInitialETHCrowdfund`.
+</Warning>
+
+4. Test your code with the *Test* button at the top-right of the IDE. You can use the range `17487000` to `17487010`. You should see one result as there was a single contribution in this range.
+
+## Build the pipeline
+
+1. Close the IDE. Click on the left handle of the Lambda component to add a `Data source`. Set *From* to 17480068, as this is when the Crowdfund Factory was deployed on Ethereum. Leave the *To* block blank as we'll let our code catch up to the tip and then continue to execute.
+
+2. Click on the right handle of the Schema component to add a `Persistence`. Name the persistence `crowdfund_contributions` and set it.
+
+3. Hit the play button on the execution edge. The code will start executing at the tip and backfilling from the *From* block. You can see its status by mousing over the `(?)`.
+
+## Setting up the APIs
+
+If we want to do some analysis, we could open the query editor and write many SQL queries against our created data. But let's just go ahead and build some APIs. 
+
+1. Add an API component to the canvas. It doesn't have to be connected to any other components. For the first API, let's do a simple one that shows the top N contributors for a specific crowdfund:
+
+```sql
+select contributor,
+sum(cast(amount as double)) as contributions 
+from @org.crowdfund_contributions
+where crowdfund = $crowdfund
+group by contributor
+order by contributions desc
+limit $limit
+```
+
+2. For the `crowdfund` and `limit` parameters, use `address` and  `uint32`, respectively. Default values are optional, but `0xa3bad5098f9489f536342ca9957bbc808d9d5d96` and `10` make sense. Test the API and activate it.
+
+3. For the second API, we want to get the top crowdfunds by total\_contributions. You can use the same type and default value for the limit parameter as above:
+
+```sql
+with latest_gc as (
+  select crowdfund,
+    max(cast(global_counter as double)) as latest_gc
+  from @org.crowdfund_contributions
+  group by crowdfund
+)
+select b.crowdfund, b.party_name, b.block_number, b.min_required, b.max_required, b.total_contributions,
+  ((1.0 * b.total_contributions) * 100 / (1.0 * b.min_required)) AS pct_of_min,
+  ((1.0 * b.total_contributions) * 100 / (1.0 * b.max_required)) AS pct_of_max,
+  passed_min
+  from @org.crowdfund_contributions b
+  inner join latest_gc lgc on b.crowdfund = lgc.crowdfund and b.global_counter = lgc.latest_gc
+order by total_contributions desc
+limit $limit
+```
+
+Give them a try using the test interactions and the cURL requests! Note that this setup also easily supports time-travel, i.e., you can get the contributor leaderboard or crowdfund leaderboard at any point in time by including `where block_number <= [some_block_number]` in the queries. You could also make the block number a parameter to support time-traveling in the API request.
+
+## Key takeaways
+
+<Tip>
+1. sim's unique [Global Counter](/sim/more-details/global-counter) allows us to order emitted messages, even within the same internal transaction!
+2. sim's `Input ABI via address` makes it a breeze to target all contracts implementing the same interface.
+3. We can create as many APIs as we want and point them to the same table.
+</Tip>

--- a/sim/example-canvases/powering-bots-with-webhooks.mdx
+++ b/sim/example-canvases/powering-bots-with-webhooks.mdx
@@ -1,0 +1,145 @@
+---
+title: Powering Bots with Webhooks
+description: Let's make a Farcaster bot powered by on-chain data emitted through webhooks
+---
+
+## Goal
+
+People love bots, but creating a bot with the existing blockchain infrastructure solutions out there is hard. Even just getting access to the raw on-chain data can be hard. Luckily, these are problems of the past when using sim.
+
+In this example, we show how we created a simple [Farcaster bot](https://warpcast.com/whalewatch) that posts a cast upon any whale transfer (Ether or any ERC20). We use Uniswap V3 as the price oracle--recall we used Uniswap V2 in [another example](/sim/example-canvases/on-chain-prices)--and emit a webhook whenever the USD value of the transfer is above a threshold. 
+
+<Note>
+If you want to skip to the end, here's [the canvas](https://studio.sim.io/canvases/ef1c9d5a-ed48-421b-9262-a59ee754e7e5) that already has everything built.
+</Note>
+
+## Steps
+
+Here's a high-level overview of the pipeline we are going to build: 
+
+<img src="https://files.readme.io/9257a41-Screenshot_2024-04-16_at_11.27.19.png" alt="Pipeline overview" />
+
+## Before you start
+
+<Warning>
+You need a place to run your server that receives the webhooks and casts to Farcaster. We are using [Heroku](https://heroku.com), but you can use any sort of provider that allows webhooks. We often use [https://webhook.site](https://webhook.site) to prototype our webhooks.
+</Warning>
+
+## Setting up the pipeline
+
+### Adding components
+
+1. Start by adding a *Data source* component. We want our pipeline to run at the tip, so we leave *To* blank and set *From* to something close to the latest block number. 
+
+2. Add an *EVM Lambda* component and connect it to the right handle of the data source. For now, leave it as is. We'll come back to it in a bit.
+
+3. Then we add a *Schema* with the metadata we need for each cast. Draw a connection from the lambda to the schema component and populate the schema as follows:
+
+| Name                 | Type    |
+| -------------------- | ------- |
+| txn\_hash            | bytes32 |
+| from\_address        | address |
+| from\_resolved\_name | string  |
+| token\_name          | string  |
+| usd\_amount          | uint256 |
+| is\_contract         | bool    |
+
+4. Finally we add a *Webhook* component. Point it to the server instance you have running and set a rate limit if you want. Then connect the schema to the webhook component.
+
+<Tip>
+You're all set! 🎉
+</Tip>
+
+### Writing the code
+
+We want to hook on transfers of ether and ERC20s. Within both of those callbacks we want to look up the USD value of the transfers. If it is above our threshold, we emit a message to the webhook.
+
+1. We add a `Transaction` hook from the `Global hook` section and a `transfer` hook from the `Predefined ERC`-> `ERC20` hook section. Make them *post* hooks and call them `postTransaction` and `postErc20Transfer`, respectively.
+
+2. The callback is very similar for the two hooks. Here's `postTransaction`. 
+
+```solidity
+CallContext storage ctx = getCallContext();
+uint256 transferEthValueUsd = getUsdcTokenPrice(WRAPPED_ETH, ctx.value); 
+
+if (WHALE_ALERT_LIMIT_USD < transferEthValueUsd){
+  simEmitToSchema_whale_alert(
+      SchemaWhale_alertColumns({
+          txn_hash: ctx.txn.hash(),
+          from_address: ctx.txn.from(),
+          from_resolved_name: getEnsName(ctx.txn.from()),
+          token_name: "ETH",
+          usd_amount: transferEthValueUsd,
+          is_contract: isAddressContract(ctx.txn.from())
+      })
+  );
+}
+```
+
+<Note>
+The `getUsdcTokenPrice` function fetches the price of the token in terms of USD by calculating the price using a Uniswap V3 pool. If the amount is greater than our `WHALE_ALERT_LIMIT_USD` threshold we emit a Webhook message to the schema.
+</Note>
+
+3. That's basically it! Check the [canvas](https://studio.sim.io/canvases/ef1c9d5a-ed48-421b-9262-a59ee754e7e5) for the full code. You'll see that we also added some logic to use the ENS reverse resolver to find a name, where one exists, for the transferrer. We got a little carried away wanting the bot to be hip and cool. Please follow [it](https://warpcast.com/whalewatch)...
+
+## A server to handle the webhooks
+
+When a Webhook request reaches the server, we need to inspect the data and cast to Farcaster.
+
+1. Here is the high-level version of the code. In short, we have a flask server running waiting for a request, we validate the signature on a request, and then post a constructed message to Farcaster.
+
+```python
+import os
+from farcaster import Warpcast
+from flask import Flask, request
+
+# [... helper functions etc.]
+
+mnemonic = os.environ.get("MNEMONIC")
+assert mnemonic, "Mnemonic seed not found."
+client = Warpcast(mnemonic=mnemonic)
+cache = MessageCache()
+
+app = Flask(__name__)
+
+@app.route('/post', methods=["POST"])
+def post():
+    # Verify that the message is from our sim-studio instance
+    provided_signature = request.headers["svix-signature"].split(",")[1]
+    generated_signatured = get_webhook_signature()
+    assert provided_signature == generated_signatured, "We only post authenticated messages"
+
+    text = format_message(request.json)
+    response = client.post_cast(text=text)
+    return response.cast.hash
+```
+
+2. The other function worth sharing is the one that validates the request. Since you are exposing the server on the internet, it is recommended to have this validation in place to prevent misuse. You can read more about the svix validation [here](https://docs.svix.com/receiving/verifying-payloads/how-manual).
+
+```python
+def get_webhook_signature():
+    svix_id = request.headers["svix-id"]
+    svix_timestamp = request.headers["svix-timestamp"]
+    body = request.get_data(as_text=True)
+    signed_content = f"{svix_id}.{svix_timestamp}.{body}"
+    secret = os.environ.get("WEBHOOK_SECRET")
+    assert secret is not None, "missing webhook secret"
+    secret_bytes = base64.b64decode(secret.split('_')[1])
+
+    signature = hmac.new(secret_bytes, msg=signed_content.encode('utf-8'), digestmod=hashlib.sha256).digest()
+    signature_base64 = base64.b64encode(signature).decode('utf-8')
+
+    return signature_base64
+```
+
+## Key takeaways
+
+<Tip>
+You have seen how easy it is to write a bot using sim. Now think of what's possible:
+
+1. Protocol monitoring, e.g., detecting abnormal activity. Call a webhook whenever the parameters of a protocol cross some threshold.
+2. Seeking alpha, e.g., be notified through a webhook on transfers from high profile accounts or when they interact with some recently deployed smart contract. 
+3. Other on-chain events, e.g., get a notification each day about new nouns minted through [Nouns DAO](https://nouns.wtf/).
+</Tip>
+
+Build your own bot, or some other application of webhooks. It probably won't be as cool as [whalewatch](https://warpcast.com/whalewatch), but go ahead and try. [Join our Telegram](https://t.me/+zw0fuNoYg39hZWRh) to brag about it.

--- a/sim/example-canvases/tracking-erc721-transfers.mdx
+++ b/sim/example-canvases/tracking-erc721-transfers.mdx
@@ -1,0 +1,113 @@
+---
+title: Tracking ERC721 Transfers
+description: We build APIs for recent Nouns transfers and a leaderboard of most popular NFTs (by transfer counts)
+---
+
+Let's index ERC721s / NFTs, tracking any instance in which one transferred. In this canvas, we'll hook on all contracts that implement the ERC721 standard and track the Transfer log.
+
+The ERC721 standard actually includes three transfer functions: transferFrom, and two variants of safeTransferFrom. The same Transfer event is typically emitted in each of these cases, as well as often for mint and burn ops.
+
+<Note>
+If you want to skip to the end, here's [the canvas](https://studio.sim.io/canvases/77a5bd7a-089c-46e7-8a48-3440c757e161) that already has everything built.
+</Note>
+
+<iframe 
+  src="https://studio.sim.io/embed/77a5bd7a-089c-46e7-8a48-3440c757e161" 
+  title="ERC721 Transfers Canvas" 
+  width="100%" 
+  height="400px" 
+  frameborder="0">
+</iframe>
+
+## Set up the Lambda
+
+1. Add an EVM Lambda to the canvas. For the hook, choose ABI > Classification > ERC721 and hit enter. Select the `Transfer` log hook. Leave the default hook position (`Post`) and callback name (`postTransferLog`). Toggle on the `Generate schema` feature as it'll give us a good template. Then hit `Add`.
+
+2. A `TransferLog` schema is automatically generated with a few fields. Hit the `Test` button at the top-right of the IDE and then hit `Run`. You'll see logs emitted to the console.
+
+3. Now let's add more details and re-arrange: click the menu next to the schema and select `Edit`. Add fields and rearrange:
+
+   | Name          | Type    |
+   | ------------- | ------- |
+   | txnHash       | bytes32 |
+   | globalCounter | uint256 |
+   | blockNumber   | uint64  |
+   | tokenAddress  | address |
+   | tokenId       | uint256 |
+   | fromAddress   | address |
+   | toAddress     | address |
+
+4. When you're done editing the schema, hit `Save`. Now we need to update the callback to emit the new data:
+
+```solidity
+function postTransferLog() public {
+    postTransferLogContext storage ctx = getPostTransferLogContext();
+    simEmitToSchema_TransferLog(
+        SchemaTransferLogColumns({
+            txnHash: ctx.txn.hash(),
+            globalCounter: simGlobalCounter(),
+            blockNumber: block.number,
+            tokenAddress: ctx.txn.to(),
+            tokenId: ctx.tokenId,
+            fromAddress: ctx.from,
+            toAddress: ctx.to    
+        })
+    );
+}
+```
+
+5. Test again when you're done and you'll see the extra fields in the emitted logs.
+
+## Build the pipeline
+
+1. Close the IDE for the EVM Lambda component. You'll see a Schema component was automatically added to your canvas.
+
+2. Click on the left handle of the Lambda component to add a `Data source`. In the data source component, set the *From* in the block range to 1. While the ERC721 standard was formally accepted in early 2018, we'll run from genesis to include contracts that implemented the standard before its acceptance. Leave the *To* blank to let it keep running at the tip.
+
+3. Click on the right handle of the Schema component to add a `Persistence`. Name the persistence something like `erc721_transfers` and set the persistence.
+
+4. Hit the play button on the execution edge. In a few moments, we should see both tip and backfill executions in the execution edge status (mouse over the `i`).
+
+## Querying and building APIs
+
+You can prototype queries using the query editor. Let's use some we've prebaked to make APIs.
+
+1. Add an API component to the canvas. It doesn't have to be connected to any other components. For the first API, let's do a simple one that shows the N most recent Nouns owner changes. Use the following query:
+
+```sql
+select * from @org.erc721_owner_changes
+where tokenAddress = '0x9c8ff314c9bc7f6e59a9d9225fb22946427edc03'
+order by globalCounter desc
+limit $limit
+```
+
+2. For the `limit` parameter, use type `uint32` (a few others would work too), and set the default value to 1.
+
+3. Test the query using the test interaction, then set the API, activate it, and try the cURL request available in the actions menu.
+
+4. For our second API, let's build a leaderboard of the most popular NFT contracts over a user-defined block range, sorting by the number of transfers. Here's a query for that:
+
+```sql
+with most_recent_block as (
+    select max(blockNumber) as most_recent_block from @org.erc721_transfers
+)
+select 
+    tokenAddress,
+    count(*) as cnt
+from @org.erc721_transfers
+where blockNumber >= (select * from most_recent_block) - $block_range
+group by tokenAddress
+order by cnt desc
+limit $limit
+```
+
+5. Both `block_range` and `limit` parameters can be typed as `uint32`, and `1000` and `5` would make sense as default parameters. Again, test the query and API using the test feature and the cURL.
+
+## Key takeaways
+
+<Tip>
+1. You can easily hook on all contracts that implement a certain standard, like ERC721, even if they have vastly different implementations.
+2. You can query and build APIs against all of your persistences as well as sim core tables from any canvas.
+</Tip>
+
+[Join our Telegram](https://t.me/+zw0fuNoYg39hZWRh)

--- a/sim/getting-started/a-simple-api.mdx
+++ b/sim/getting-started/a-simple-api.mdx
@@ -1,0 +1,182 @@
+---
+title: A Simple API
+description: In this tutorial, we'll build out a complete (but simple!) canvas with an API for ERC20 balance change data.
+---
+
+<Note>
+**Requirements:** You've already created your user account and an organization and are familiar with the basics covered in [Hello, Lambda!](/sim/getting-started/hello-lambda)
+</Note>
+
+This tutorial takes you through a full data pipeline. For some use cases, you may be able to build your API on existing tables, or even use sim's fully configurable API templates. Before we jump into the full pipeline, here's a video on API templates:
+
+<iframe 
+  width="100%" 
+  height="400" 
+  src="https://www.youtube.com/embed/jr7sqFezsz4" 
+  title="API templates" 
+  frameborder="0" 
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+  allowfullscreen>
+</iframe>
+
+## EVM lambda and schema
+
+1. Create a new canvas. Using the expansible left canvas sidebar, add an *EVM Lambda* and a *Schema* component. Drag an edge from the right border of the *Code* component to the left border of the *Schema* component to connect them.
+
+2. We're going to emit data for ERC20 balance changes. Name the schema `erc20_balance_changes` and populate the schema per the following table and then hit **Save**. Note that you can also define and edit schemas within the *EVM Lambda*, which is handy when you don't know at the outset the exact data or types you wish to emit.
+
+| Name             | Type    |
+| :--------------- | :------ |
+| txn\_hash        | bytes32 |
+| block\_number    | uint64  |
+| token\_address   | address |
+| account\_address | address |
+| value\_before    | uint256 |
+| value\_after     | uint256 |
+
+3. Open the IDE in the EVM lambda component with the edit button.
+
+4. In the *Add hooks* flow, select **ABI**. Then select **Classification** and **ERC20**. Note that this means any hook you select will be triggered against each contract whose ABI includes the functions and logs in the ERC20 classification.
+
+5. Because we want to emit data about ERC20 balance changes, we'll use the **erc20\_balances** storage hook to insert our code after each balance change. Leave the callback name default: `postErc20_balancesStorage` and hit **Add hook**.
+
+6. Place your cursor within the callback in the code-editor and insert your schema function into the lambda code by hitting the `->` next to the schema.
+
+<Warning>
+**Solidity + abstractions (ctx and simFunctions)**
+
+When it comes to defining the data you wish to emit, your code is a Solidity smart contract. Anything you can do in Solidity, you can do within your callbacks. But we also provide two sets of abstractions to make the work easier and enable use cases that would otherwise be impossible:
+
+1. **Hook context (ctx):** For each hook, we pass a struct to the callback containing data you're likely to need for that hook. You can see the options in autocomplete by typing `ctx.`within the callback. 
+2. **simFunctions:** Some things are easy in Solidity; if you want the block number, just do `block.number`. Others are hard; there's no direct way in Solidity to access the transaction hash from within the executing contract because the transaction hash can only be determined after the transaction is signed and broadcasted, which is outside the scope of what's accessible during contract execution. So we just give it to you in `simTransactionHash()`. You can see all the available *simFunctions* in the *simFunction* IDE sidebar and read their documentation [here](/sim/reference/simfunctions/index).
+
+The two abstractions have some overlap: you could get the transaction hash in the case of this example either via `simTransactionHash()` or `ctx.txn.hash()`.  But generally speaking the `ctx` is for data that's very specific to the hook and *simFunctions* provide more general functionality.
+</Warning>
+
+7. For the purposes of this exercise, populate your schema function, within the callback, with the following code.
+
+```solidity
+function postErc20_balancesStorage() public {
+    postErc20_balancesStorageContext storage ctx = getPostErc20_balancesStorageContext();
+    simEmitToSchema_erc20_balance_changes(
+        SchemaErc20_balance_changesColumns({
+            txn_hash: ctx.txn.hash(),
+            block_number: uint64(block.number),
+            token_address: ctx.txn.to(),
+            account_address: ctx.path.owner,
+            value_before: ctx.valueBefore,
+            value_after: ctx.valueAfter
+        })
+    );
+}
+```
+
+<Warning>
+**(Internal) transaction scoping**
+
+When you use a *simFunction* relating to transaction context, or a context object like `ctx.txn.to()`, it is scoped to the deepest currently executing internal transaction in the hook, unless otherwise noted. Even though an ERC20 token address is often not the recipient of an external transaction that changes balances, it is the recipient of an internal transaction therein in which the balance change takes place, meaning the logic above identifies the `token_address` correctly in all cases.
+</Warning>
+
+8. Test the interaction. Any block range will work for this because ERC20 transfers are so common. When you hit **Confirm**, you should see many ERC20 transfers in the IDE console log.
+
+<img 
+  src="https://files.readme.io/c3c8dd3-Screenshot_2024-03-11_191558.png" 
+  alt="ERC20 transfers in console log" 
+  className="border" 
+/>
+
+<Note>
+**Test interactions**
+
+When you test within the IDE, both `simConsoleLog()` and `simEmitToSchema_[schema_name]` populate to the console.
+</Note>
+
+## Data source and persistence
+
+We now have a functioning, tested lambda. We want to take the next step by defining the full block range upon which we want to run the code and the persistence where we want to store the data.
+
+1. Close the IDE with the **X** next to the *Test* button.
+
+2. Add a **Data source** component to the left of the *Code* component. You can do this by clicking on the code component, dragging to the desired location, and releasing. Draw an edge from the right of the new *Data source* component to the left of the existing *Code* component.
+
+3. Add a **Persistence** component to the right of the *Schema* component. Draw an edge from the right of the existing *Schema* component to the left of the new *Persistence* component.
+
+4. Name the table in the persistence component `erc20_balance_changes` and hit **Set**. Note that the primary key is used only for avoiding duplicates, not as an index. In this case, we needn't worry about duplicates, so there is no need to set a primary key by checking any of the checkboxes.
+
+5. In the *Data source* component, set a block range that you wish to run on. If you don't specify an end block, it will keep running to and at the tip. For the purposes of this tutorial, use a small range and then hit the triangle **Play** button.
+
+<img 
+  src="https://files.readme.io/0b23acb-image.png" 
+  alt="Data source component" 
+  className="border" 
+/>
+
+While executing, you can hover over the `(!)` button to see the execution status. With a small block range, it will complete very quickly.
+
+## Query
+
+Now that we have some data in the persistence, we can query it!
+
+1. Open the query editor using the icon in the left sidebar.
+
+2. Create a new query using the button at the top right of the query editor. Now let's write a SQL query. To reference your table, you must use `@org.[table_name]`. Here's a sample query that you can run to see results.
+
+```sql
+select *
+from @org.erc20_balance_changes
+where token_address = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+and block_number = 17000001
+limit 5
+```
+
+## API
+
+1. Now, let's close the the query editor using the `x` at top-right and add an `API` component to the canvas. The API doesn't need to be connected to any other components, and can be placed anywhere.
+
+2. We'll build an API that returns all balance change records for a given token and block that's specified in the request. We'll also allow the user to specify the max number of records they want back. To do this, we use `$parameter` syntax. Here's the query to put into the API component.
+
+```sql
+select *
+from @org.erc20_balance_changes
+where token_address = $token
+and block_number = $block 
+limit $limit
+```
+
+3. In the API component, below the query input, three parameters will populate: `token`, `block`, and `limit`. For their types, select `address`, `uint64`, and `uint32`, respectively. 
+
+4. We can also populate default values for each parameter. When you interact with the endpoint, supplying values for parameters with default values is optional--if unspecified, the API will use the default. For now, let's use `0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`, `17000001`, and `1` respectively.
+
+5. You can test the query or just go ahead and close it and hit `Set` on the API. The toggle at the top-right of the component will automatically toggle to the activated state. From the menu at the top right, select `Copy cURL request` and paste it into a terminal. It should look something like this:
+
+```bash
+curl --location https://api.evm.storage/canvas_api.v1.CanvasApiService/Query --header 'Content-Type: application/json' --data '{
+    "canvas_id": "b9de2bff-6a97-4b08-a91f-577198dc5576",
+    "api_endpoint": "api_1",
+    "api_key": "sim-api-b22b5d53e81c6239",
+    "query_parameters": {"token":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48","block":"17000001","limit":"1"}
+}
+'
+```
+
+6. Run it in the terminal and you'll get a response. Because the parameters had default values, this also works:
+
+```bash
+curl --location https://api.evm.storage/canvas_api.v1.CanvasApiService/Query --header 'Content-Type: application/json' --data '{
+    "canvas_id": "b9de2bff-6a97-4b08-a91f-577198dc5576",
+    "api_endpoint": "api_1",
+    "api_key": "sim-api-b22b5d53e81c6239",
+    "query_parameters": {}
+}
+'
+```
+
+<Warning>
+**cURL requests on Windows**
+
+Copy cURL request generates a multiline Bash request that, when given parameters, should work well on UNIX/Linux systems, including Apple. If you're using Windows, Command Prompt doesn't like the newlines and PowerShell uses a `Invoke-RestMethod` instead of `curl`. Just give an AI assistant the supplied cURL request and ask it to reformat it for Command Prompt--consider this your punishment for using Windows. Another option, which some of us like, is to use Linux on Windows via WSL.
+</Warning>
+
+<Tip>
+**Recap:** In this tutorial, we built an API that served records for every ERC20 balance change for a user-supplied contract and block number.
+</Tip>

--- a/sim/getting-started/account-setup.mdx
+++ b/sim/getting-started/account-setup.mdx
@@ -1,0 +1,38 @@
+---
+title: Account Setup
+description: Welcome to sim Studio! Let's get you started by creating an account and an organization.
+---
+
+<iframe 
+  width="100%" 
+  height="400" 
+  src="https://www.youtube.com/embed/_SoJQ0myJhY" 
+  title="Onboarding with sim" 
+  frameborder="0" 
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+  allowfullscreen>
+</iframe>
+
+## Steps
+
+1. Sign up with a variety of auth options at [studio.sim.io](https://studio.sim.io/).
+
+<img src="https://files.readme.io/b006896-Screenshot_2024-05-18_at_7.25.58_PM.png" width="400" alt="Sign up options" />
+
+2. Create an org by choosing a name and a slug URL.
+
+<img src="https://files.readme.io/5dcd6ae-image.png" width="400" alt="Create organization" />
+
+3. (Optional) Invite members. sim users can be part of multiple orgs at the same time
+
+<img src="https://files.readme.io/8963457-Screenshot_2024-05-18_at_7.44.03_PM.png" width="400" alt="Invite members" />
+
+You'll then be redirected to your new org's canvases page.
+
+<img src="https://files.readme.io/31f7acd-Screenshot_2024-05-18_at_7.19.24_PM.png" width="100%" alt="Canvases page" className="border" />
+
+<Note>
+**Congrats, you now have an account and organization for sim Studio!**
+</Note>
+
+<img src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNTRlanFvbWJ2cWVuZG8zYnlieHhnNjYxcGJ3OXhxd3UyemlyOHYzayZlcD12MV9naWZzX3NlYXJjaCZjdD1n/d2jjIRvGomz6GMkU/giphy.gif" alt="Celebration gif" />

--- a/sim/getting-started/hello-lambda.mdx
+++ b/sim/getting-started/hello-lambda.mdx
@@ -1,0 +1,44 @@
+---
+title: Hello, Lambda!
+description: In this tutorial, we're going to insert some code into blockchain execution with an evm lambda.
+---
+
+<Note>
+**Requirements:** You've already created your user account and an organization.
+</Note>
+
+## Steps
+
+1. Create a new canvas using the **Create** button at the top right of the *Canvases* table.
+
+2. Insert an EVM Lambda component using the expansible canvas sidebar at the left of the canvas.
+
+3. Click the :pencil2: icon in the new lambda component to open the integrated development environment (IDE).
+
+4. In the `Add hooks` menu, select the **Address** type. Let's target *vitalik.eth*: `0xd8da6bf26964af9d7eed9e03e53415d37aa96045`. You'll be given an option to input an ABI for this address, but in this case it's an externally owned account (EOA) so it doesn't have an ABI. Just hit **Enter** to proceed.
+
+5. Select **TransactionFrom**. Leave the default checkbox in **Post**, meaning we'll insert our code after each transaction from *vitalik.eth*. Toggle on **Generate schema** to save us some work. Click **Add hook**.
+
+<img 
+  src="https://files.readme.io/433cd71-2024-07-04_10_09_35-Clipboard.png" 
+  alt="Add hook interface" 
+  className="border" 
+/>
+
+6. As soon as you add the hook, a the `TransactionFrom` schema is automatically generated and populated in the lambda code. Hit the test button and let's run it from `19365540` to `19365541`. The test logs will pop open with a record for the transaction from *vitalik.eth* in block `19355540`.
+
+<Tip>
+**Recap:** In this tutorial we hooked on each instance in which *vitalik.eth* was the sender of a transaction and emitted a record based on an auto-generated and auto-populated schema.
+</Tip>
+
+## While you're here...
+
+1. Try testing again but with the block range incremented by one: `19365541` to `19365542`. You'll find empty logs from this test because `vitalik.eth` sent no transactions in that block range.
+
+2. Within the callback function, `postTransactionFrom`, type `ctx.` and view the autocomplete options. All of this data is available within the context of each transaction hook. You can convert some of it to a string and emit it as a separate console log, e.g. `simConsoleLog(simToString(ctx.caller))` returns *vitalik.eth*'s address. We'll learn later how to emit this data to persistences and webhooks.
+
+<img 
+  src="https://files.readme.io/1225203-Screenshot_2024-03-11_142941.png" 
+  alt="Context autocomplete options" 
+  className="border" 
+/>

--- a/sim/getting-started/querying-data.mdx
+++ b/sim/getting-started/querying-data.mdx
@@ -1,0 +1,43 @@
+---
+title: Querying Data
+description: Let's query some existing tables in sim Studio
+---
+
+<Note>
+**Requirements:** You've already created your user account and an organization.
+</Note>
+
+## Steps
+
+1. From your org dashboard, open the query editor by hitting the `Queries` button.
+
+<img src="https://files.readme.io/b640409-2024-07-04_07_25_59-Clipboard.png" alt="Query button" />
+
+2. Explore the query editor's three sidebars: `Tables`, `Queries`, and `Templates`.
+   - The tables sidebar shows all persistences that belong to your organization as well as all `sim` core tables. If you open the query editor from a canvas that contains active persistence components, those tables will also be highlighted as Canvas tables.
+   - The queries sidebar shows all of your queries. Queries are owned at the user-level, not at the org-level, so your collaborators won't see you queries unless you share with them.
+   - The templates sidebar shows some common pre-built queries.
+
+3. In the query editor, write a simple SQL query like `select * from @sim.blocks limit 10`. Then hit the Run button at the top right.
+
+4. You can add parameters to a query using the `$` sign. Try replacing `limit 10` with `limit $limit` and then hit the run button again. This time it will ask you to define a type and value for the parameter. Parameters are helpful when you're running the same query frequently with different values and/or prototyping a query you intend to use in an API.
+
+5. Try adding a new query with the `+` button.
+
+## Basic query tips
+
+<Tip>
+Here are some helpful tips for writing effective queries in sim Studio:
+</Tip>
+
+1. It's SQL... We use Pinot's multistage engine. Pinot has [documentation](https://docs.pinot.apache.org/users/user-guide-query) available.
+
+2. Always use a limit unless you know your result set is small. We help you with this with the `limit 100` checkbox.
+
+3. Often the second time you run a query will be significantly faster than the first because the relevant data segments stay loaded in memory.
+
+4. Filter with `where` early and often. Pinot has automatic indexing for all columns, so you should easily be able to filter on any column.
+
+5. Addresses are stored as lower case strings. If you have a checksummed address, convert it to lower case, e.g., `where account_address = lower('0x48D004a6C175dB331E99BeAf64423b3098357Ae7')`.
+
+You now know how to query existing tables. That'll only get you so far in life...

--- a/sim/index.mdx
+++ b/sim/index.mdx
@@ -1,0 +1,55 @@
+---
+title: Welcome to sim Studio
+description: A unified platform for blockchain data computation, storage, and serving/querying
+---
+
+# What is sim Studio?
+
+sim Studio is a unified platform for blockchain data computation, storage, and serving/querying.
+
+<iframe 
+  width="100%" 
+  height="400" 
+  src="https://www.youtube.com/embed/nxnen9iYBxw" 
+  title="YouTube video player" 
+  frameborder="0" 
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+  allowfullscreen>
+</iframe>
+
+## What can I build?
+
+We have prebuilt API templates and core tables that you can query and build upon and we will continue extending them. But with our flexible EVM lambdas for code insertion and configurable canvases, you can build just about any blockchain data pipeline that you can imagine with sim Studio. We built [evm.storage](https://evm.storage) with it. Obvious use cases include:
+
+1. Indexing blockchain data
+2. Building a dApp
+3. Enriching transparency for a protocol
+4. Monitoring and incident response
+
+But pretty much any application and workload that can benefit from being synchronized to on-chain state and activity can benefit from sim.
+
+You can see examples of each of these use cases at [sim.io](https://sim.io).
+
+## What chains are supported?
+
+For now: Ethereum, Arbitrum and Base (+Sepolia). Avalanche and Optimism are coming soon and we'll continue to add more in the future, if not having a specific chain is a reason you don't use sim, do reach out to us.
+
+## How much does it cost?
+
+We're still working out the details for paid tiers with additional features. But sim has a rich free tier (no credit card needed) with some restrictions on backfill and API quotas, if you happen to hit these limits do reach out. Our infra is efficient and scales well, so our pricing will be competitive and we aim to offer much higher value compared to other vendors or building pipelines yourself.
+
+<Note>
+If you have a project you are excited about and cost is a factor, do reach out to us.
+</Note>
+
+## How much technical knowledge do I need?
+
+With our API templates and core tables, you can build a production-ready API with no technical knowledge at all. But it's also extremely flexible: you can write your own queries and build APIs against our core tables with just simple SQL. When you're ready to generate your own blockchain data, dive into EVM lambdas. Our IDE generates and populates functional schemas for you, and we have many abstractions in hook context and simFunctions to make it easy to get the data you're looking for. You can also start by duplicating one of our example canvases. Even if you've never written *any* code before, it's very doable.
+
+## What if I get stuck?
+
+Join our [smlXL - sim Telegram group](https://t.me/+zw0fuNoYg39hZWRh) or email [shane@smlxl.io](mailto:shane@smlxl.io). Don't hesitate to reach out: if something's not working as you anticipate, or you can't work out how to do something, that's feedback that we really want. We're happy to help.
+
+## How do I get started?
+
+Check out our tutorials and examples right here in the documentation hub. [Dive in](https://studio.sim.io/).

--- a/sim/more-details/custom-types.mdx
+++ b/sim/more-details/custom-types.mdx
@@ -1,0 +1,125 @@
+---
+title: Custom types
+excerpt: Emit custom types from a Lambda or Patch
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+# Summary
+
+When you emit a variable from sim Lambdas or Patches, you typically pick from one of the standard available types: `address`, `bool`, `bytes`, `bytes32`, `int256`, `int64`, `string`, `uint256`, `uint64`. If you connect a persistence, we automatically ingest these into the table using DB types that are best suited for each. Sometimes, however, you may want to emit data that doesn't fit neatly within these standard types.
+
+To define a custom type, open the `Schema types` tab within any Patch or Lambda component. This tab is global within a canvas, i.e., you can enter custom types in it within any component and use them within other components.
+
+<Image align="center" className="border" width="400px" border={true} src="https://files.readme.io/80611582d9faeb8483bd89b9dbb3c56c5c06a2f76c70fe21f7546492478fbcf2-image.png" />
+
+Once in the tab, define a custom type using a struct. For instance, you could define a type for a simple array of addresses as follows:
+
+```sol
+struct AddressArray {
+    address[] addresses;
+}
+```
+
+With this type created, you can now use it in your schemas by selecting it as a type. You can edit schemas either within the IDE or by editing the component directly in the canvas.
+
+<Image align="center" className="border" width="300px" border={true} src="https://files.readme.io/c5bf44bbc5f583e502cab85f1654ccc4bb0130f014341fcbbb8791d5b3522854-image.png" />
+
+Finally, in any callback within the lambda, you can create and emit a variable of the custom type. An example:
+
+```sol
+AddressArray memory addrArray;
+addrArray.addresses = new address[](1) ;
+addrArray.addresses[0] = address(0);
+
+simEmitToSchema_mySchema(
+  SchemaMySchemaColumns({
+    myArray: addrArray
+  })
+);
+```
+
+> ❗️ Prefix custom types by `Sim.` in Patches
+>
+> When referencing simFunctions or custom types in a Patch component, you need to prefix with `Sim.`. Instead of `AddressArray`, write `Sim.AddressArray`.
+
+If you connect a schema with custom types to a persistence, the custom type data will flow into the persistence as a JSON. Apache Pinot has extensive support for querying JSON data--you can read their documentation [here](https://docs.pinot.apache.org/users/user-guide-query/query-syntax/json-queries).
+
+# Example: Indexing Uniswap X
+
+We ran into a use case for custom types while trying to index [UniswapX](https://blog.uniswap.org/uniswapx-protocol) trades. In simple decentralized exchanges, each swap involves exactly two tokens--the user trade's one for another--so we simply construct columns with the data we need for each of the two tokens. With UniswapX, however, a single swap may involve more than one output token.
+
+Given the number of output tokens is variable, what we really want to do is emit an array of the output tokens. And for each token, we want to emit various details. To accommodate this, we defined custom types as follows:
+
+```sol
+struct Tokens {
+    Token[] tokens;
+}
+
+struct Token {
+    address tokenAddress;
+    int tokenUsd;
+    uint8 tokenUsdDec;
+    uint256 tokenAmt;
+    string tokenName;
+    string tokenSymbol;
+    address recipient;
+}
+```
+
+Then, we populated variables `fromTokens` and `toTokens` using these custom types. We only really needed this capability for `toTokens` given that there's only ever one `fromToken`, but we did `fromTokens` also for symmetry. Because we did this within a Patch component, we prefixed the custom types with `Sim.`.
+
+```sol
+Sim.Tokens memory fromTokens;
+fromTokens.tokens = new Sim.Token ;
+
+Sim.Tokens memory toTokens;
+toTokens.tokens = new Sim.Token[](resolvedOrder.outputs.length);
+
+Sim.Token memory fromToken;
+fromToken.tokenAddress = address(resolvedOrder.input.token);
+fromToken.tokenAmt = resolvedOrder.input.amount;
+fromToken.tokenName = this.getName(fromToken.tokenAddress);
+fromToken.tokenSymbol = this.getSymbol(fromToken.tokenAddress);
+if (block.number > 12864088) {
+    (fromToken.tokenUsd, fromToken.tokenUsdDec) = getChainlinkDataFeedLatestAnswer(fromToken.tokenAddress);
+}
+fromTokens.tokens[0] = fromToken;
+
+for (uint i = 0; i < resolvedOrder.outputs.length; i++) {
+    Sim.Token memory toToken;
+    toToken.tokenAddress = address(resolvedOrder.outputs[i].token);
+    toToken.tokenAmt = resolvedOrder.outputs[i].amount;
+    toToken.tokenName = this.getName(toToken.tokenAddress);
+    toToken.tokenSymbol = this.getSymbol(toToken.tokenAddress);
+    toToken.recipient = resolvedOrder.outputs[i].recipient;
+    if (block.number > 12864088) {
+        (toToken.tokenUsd, toToken.tokenUsdDec) = getChainlinkDataFeedLatestAnswer(toToken.tokenAddress);
+    }
+
+    toTokens.tokens[i] = toToken;
+}
+```
+
+You can see the rest of the code used in the Patch in [the canvas](https://studio.sim.io/sim/canvases/e5f63d90-0d00-4d1c-aaa8-3409b66065fb). When queried, from the persistence, records in `to_tokens` are JSON. Here's an example where `to_tokens` includes a single token.
+
+```json
+{
+  "tokens": [
+    {
+      "tokenAddress": "514910771af9ca656af840dff83e8264ecf986ca",
+      "tokenUsdDec": 8,
+      "tokenSymbol": "LINK",
+      "tokenUsd": "29a9e4c0",
+      "tokenName": "ChainLink Token",
+      "recipient": "980e5dd186eb72c92565f93817cb858ae522633f",
+      "tokenAmt": "c0ffd00ebc4c2ccecc"
+    }
+  ]
+}
+```

--- a/sim/more-details/global-counter.mdx
+++ b/sim/more-details/global-counter.mdx
@@ -1,0 +1,46 @@
+---
+title: Global counter
+excerpt: Let's define an important variable and how to use it
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+# Why it exists
+
+If `x` and `y` are two distinct *executions* that happened on the same blockchain, we want to be able to say that either `x` occurred before `y` or that `y` occurred before `x`. We want that for all `x` and `y`, i.e. a strong order, sometimes called a strict total order.
+
+Note: You could use `block_number`, but that will fail if you have multiple records within a given block. You could use `(block_number, transaction_index)`, but that will fail if you have multiple records within the same transaction. Go down this rabbit hole far enough, and you'll rebuild your own version of our global counter!
+
+# When should you use it
+
+Two main use cases:
+
+1. Sort a table with execution records by their order: order by `global_counter` (descending, if you want the most recent first).
+2. Get state at a particular point in execution history (including current): find the execution records with the highest global counter up to that point in execution history.
+
+# How to use it
+
+Include `global_counter` as a `uint256` in your schemas. In your EVM lambdas, populate it with `simGlobalCounter()`. Note that the global counter is stable within each instance of a hook execution.
+
+Apache Pinot still has limited math support for `big_decimal`. We're told this will be improved soon. In the meantime, if performing math on `global_counter` is failing for you, you may consider casting it to a double first (`cast(global_counter as double`), but note that this reduces precision and therefore can yield inaccurate event ordering.
+
+# What it is
+
+You probably shouldn't read this, but if you want the gory details... The `global_counter` is 192-bits long and consists of:
+
+1. `version` (8 bits): the version of the global counter
+2. `block_number` (32 bits)
+3. `reorg_incarnation` (24 bits): Indicates how many re-orgs have happened already.
+4. `block_epilogue` (8 bits): Consensus events that happen after the last transaction of the block. These might be present even if no transactions were included in a block. It is deliberately stored in bits which are higher than the `txn_index` to denote that events that have these bits set happened *after* any transaction in that block.
+5. `txn_index` (24 bits)
+6. `block_prologue` (8 bits): Consensus events that happen before the first transaction of the block
+7. `txn_state` (8 bits): The phase we are in, relative to the transaction itself: before, within, epilogue, after
+8. `txn_state_counter` (8 bits):  What event are we in, within the `txn_state`, i.e, bytecode execution
+9. `shadow_pc` (40 bits): Only relevant if we are in bytecode execution phase. Represents the number of opcodes executed
+10. `evt_counter` (16 bits) Extra event counter to distinguish between multiple events that we may emit as a result of the execution of the same opcode. One extreme example of it would be to emit an event every time a stack item pops off. This can definitely happen multiple times when executing the same opcode, although we've never actually came up with a good use case for this :).
+11. `padding` (16 bits) Zeroes padding the counter to 192 bits. Our big-int library likes numbers that divide by 32.

--- a/sim/more-details/hook-ctx-and-simfunctions.mdx
+++ b/sim/more-details/hook-ctx-and-simfunctions.mdx
@@ -1,0 +1,24 @@
+---
+title: The ctx object and simFunctions
+excerpt: ''
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+When adding a hook your callback function comes prepopulated with a context (ctx) object that exposes key details associated with the hook. The context object will differ depending on the hook type and hooked function/log or storage.
+
+Generally speaking
+
+* Storage hooks will have: valueBefore, valueAfter (of the storage slot that was changed), and information about the storageKey/path to it and the ctx.txn object
+* Log hooks: all the decoded data of the logs, and the ctx.txn object
+* Function hooks: all the inputs and outputs of the function, the sighash of the function and  ctx.txn object
+* Transaction hooks: Will contain selected metadata of the transaction like the caller/callee, depth etc. and the ctx.txn object
+* Global storage hooks: contain the valueBefore/after of the storage slot in question, the path and the ctx.txn.object
+* Block hooks: currently contain no ctx object.
+
+Besides the context object you can also use simFunctions from within your Lambda and patches. simFunctions are abstractions we offer to allow you to perform executions that would be impossible or difficult with just Solidity. For example, you can overwrite the ETH balance of an address in a simulation using `simSetBalance`. When you add a sim function from the sidebar, it's inserted into the code editor at the location of the cursor. Sim functions are documented at [/sim/reference/simfunctions/index](/sim/reference/simfunctions/index).

--- a/sim/more-details/querying-and-data-types-faq.mdx
+++ b/sim/more-details/querying-and-data-types-faq.mdx
@@ -1,0 +1,39 @@
+---
+title: Querying and data types FAQ
+excerpt: ''
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+1. When should I use `uint256` versus downcast to `uint64`?
+   1. When you emit a `uint256` to a persistence, it is ingested by Apache Pinot as `BIG_DECIMAL`. When you emit a `uint64`, it's ingested as `LONG`. In general, Pinot math functions support `LONG` better than `BIG_DECIMAL`. Often there are work-arounds for `BIG_DECIMAL`, e.g., using `sum_precision` instead of `sum`--reach out if you're stuck and we can help.
+   2. Given the above, we recommend emitting data as `uint256` only when you need the precision. For balances, precision is crucial. For data like block numbers or timestamps, casting to `uint64` (i.e., `uint64(block.number)`) in the lambda and emitting as `uint64` in the schema might make your life easier if you later want to do `max(block_number)`.
+2. What should I do about `numeric literal out of range` errors?
+   1. This relates to Q1 above. Try a query like `select * from @sim.erc20_balance_changes_block where balance > 69803846217511559491961` and you'll run into `numeric literal out of range`. The simplest fix for this is to just pass the number as a string: `select * from @sim.erc20_balance_changes_block where balance > '69803846217511559491961'`. You can also use scientific notation: `select * from @sim.erc20_balance_changes_block where balance > 6.9e22`, but this comes with a lack of precision.
+   2. Another situation where you might run into this is if you're using [Global counter](https://docs.sim.io/docs/global-counter) as a cursor for API [pagination](https://docs.sim.io/docs/api#pagination).
+3. Is it better to use WHERE with a subquery or do an inner join?
+   1. It depends--try both and look at the execution time at the bottom of the query editor! Here are some examples of what we're talking about. 
+      ```sql WHERE with subquery
+      -- DEMO PURPOSES ONLY, TABLES DON'T EXIST
+      SELECT order_id, customer_id, order_total
+      FROM Orders
+      WHERE customer_id IN (
+          SELECT customer_id
+          FROM Customers
+          WHERE customer_status = 'active'
+      )
+      ```
+      ```sql Inner join
+      -- DEMO PURPOSES ONLY, TABLES DON'T EXIST
+      SELECT o.order_id, o.customer_id, o.order_total
+      FROM Orders o
+      INNER JOIN Customers c ON o.customer_id = c.customer_id
+      WHERE c.customer_status = 'active'
+      ```
+4. Why is my query slow? Can I make it faster?
+   1. It depends... Probably! Hit us on on Telegram--we're happy to help.

--- a/sim/more-details/storage-hooks.mdx
+++ b/sim/more-details/storage-hooks.mdx
@@ -1,0 +1,98 @@
+---
+title: Storage hooks
+excerpt: Track value changes to specific variables in contract storage
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+# Simple variables and mapping values
+
+To hook on a variable, you provide its name/path as defined in source code. For example, for [Wrapped Ether](https://www.evm.codes/contract?address=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2), you could hook on `balanceOf` or `allowance` (or `name`, `symbol`, `decimals`, but they won't be very interesting!).
+
+If you want to track a specific value within a mapping, hook on the mapping and then filter on the key in the callback.
+
+# Using slither to construct paths
+
+For complex cases where variables are nested, you can used [slither-read-storage](https://github.com/crytic/slither/blob/master/slither/tools/read_storage/README.md) to generate the layouts and construct the paths required for storage hooks:
+
+```bash
+slither-read-storage 0x8ad599c3a0ff1de082011efddc58f1908eb6e6d8 --json storage_layout.json --etherscan-apikey *your etherscan api key*
+```
+
+Open `storage_layout.json`, which contains a description of each storage variable. Input the slither `name` field to the `Variable path` input on sim.
+
+## Example 1: Simple variables
+
+If the type doesn't involves a struct, all you need to do is provide us the top level variable names for instance `liquidity` or `feeGrowthGlobal0X128` in the case of `UniswapV3Pool`.
+
+```json
+{
+    ...
+    "liquidity": {
+        "name": "liquidity",
+        "type_string": "uint128",
+        "slot": 4,
+        "size": 128,
+        "offset": 0,
+        "value": null,
+        "elems": {}
+    },
+    ...
+      "feeGrowthGlobal0X128": {
+        "name": "feeGrowthGlobal0X128",
+        "type_string": "uint256",
+        "slot": 1,
+        "size": 256,
+        "offset": 0,
+        "value": null,
+        "elems": {}
+    },
+    ...
+}
+```
+
+## Example 2: Structs
+
+In the case of structs, you need to give us the full path. `protocolFees` has two members, so you would need to define either `protocolFees.token0` or `protocolFees.token1`, depending on which variable you want to hook on.
+
+```json
+{
+  ...
+    "protocolFees": {
+        "name": "protocolFees",
+        "type_string": "UniswapV3Pool.ProtocolFees",
+        "slot": 3,
+        "size": 256,
+        "offset": 0,
+        "value": null,
+        "elems": {
+            "token0": {
+                "name": "protocolFees.token0",
+                "type_string": "uint128",
+                "slot": 3,
+                "size": 128,
+                "offset": 0,
+                "value": null,
+                "elems": {}
+            },
+            "token1": {
+                "name": "protocolFees.token1",
+                "type_string": "uint128",
+                "slot": 3,
+                "size": 128,
+                "offset": 128,
+                "value": null,
+                "elems": {}
+            }
+        }
+    },
+  ...
+}
+```
+
+If you want to hook on both, add one storage hook for each.

--- a/sim/reference/simfunctions/index.mdx
+++ b/sim/reference/simfunctions/index.mdx
@@ -1,0 +1,53 @@
+---
+title: simFunctions
+excerpt: simFunctions augment Solidity with extra abilities
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+# Transaction Context
+
+* [simCalldata](/sim/reference/simfunctions/simcalldata): Returns the calldata of the (internal) transaction
+* [simCallDepth](/sim/reference/simfunctions/simcalldepth): Returns the call depth of the currently executing (internal) transaction
+* [simCallKind](/sim/reference/simfunctions/simcallkind): Returns the call kind of the (internal) transaction
+* [simFrom](/sim/reference/simfunctions/simfrom): Returns the from address of the (internal) transaction
+* [simGas](/sim/reference/simfunctions/simgas): Returns the amount of gas assigned to this (internal) transaction
+* [simGasLeft](/sim/reference/simfunctions/simgasleft): Returns the gas remaining after an (internal) transaction
+* [simTo](/sim/reference/simfunctions/simto): Returns the to address of the (internal) transaction
+* [simValue](/sim/reference/simfunctions/simvalue): Returns the value sent with the (internal) transaction
+* [simTransactionGasLimit](/sim/reference/simfunctions/simtransactiongaslimit): Returns the gas limit of the transaction
+* [simTransactionHash](/sim/reference/simfunctions/simtransactionhash): Returns the transaction hash
+* [simTransactionIndex](/sim/reference/simfunctions/simtransactionindex): Returns the index of the transaction within its block
+* [simTransactionStatus](/sim/reference/simfunctions/simtransactionstatus): Returns the transaction status
+* [simCodeAddress](/sim/reference/simfunctions/simcodeaddress): Returns the code address of the (internal) transaction
+* [simCreatedContract](/sim/reference/simfunctions/simcreatedcontract): Returns the gas remaining after an (internal) transaction
+* [simImplementsFunction](/sim/reference/simfunctions/simimplementsfunction): Checks if a contract implements a function
+* [simParentCodeAddress](/sim/reference/simfunctions/simparentcodeaddress): Returns the parent code address of the (internal) transaction
+* [simSalt](/sim/reference/simfunctions/simsalt): Returns the salt of a CREATE2 transaction
+
+# Storage and State
+
+* [simReadStorage](/sim/reference/simfunctions/simreadstorage): Reads storage for specified (contract, slot)
+* [simSetStorage](/sim/reference/simfunctions/simsetstorage): Overwrites the contents of any (contract, slot)
+* [simStorageAddress](/sim/reference/simfunctions/simstorageaddress): Returns the address whose slot was read/written
+* [simStorageKey](/sim/reference/simfunctions/simstoragekey): Returns the key of the slot that was read/written
+* [simStorageValue](/sim/reference/simfunctions/simstoragevalue): Returns the value of the slot that was read/written
+* [simSetBalance](/sim/reference/simfunctions/simsetbalance): Overwrite the native token balance of a given address
+
+# Logs and Events
+
+* [simEmitsLog](/sim/reference/simfunctions/simemitslog): Checks if a contract emits a log
+* [simLogAddress](/sim/reference/simfunctions/simlogaddress): Get the address that emitted a log
+* [simLogData](/sim/reference/simfunctions/simlogdata): Returns the unindexed event data of a log
+* [simLogTopic](/sim/reference/simfunctions/simlogtopic): Returns a topic from a log
+* [simLogTopicSize](/sim/reference/simfunctions/simlogtopicsize): Returns the number of topics in a log
+
+# Utilities
+
+* [simAddressNonce](/sim/reference/simfunctions/simaddressnonce): Returns the nonce of an address
+* [simToString](/sim/reference/simfunctions/simtostring): Converts many data types to string for easy logging

--- a/sim/reference/simfunctions/log.mdx
+++ b/sim/reference/simfunctions/log.mdx
@@ -1,0 +1,21 @@
+---
+title: simConsoleLog
+excerpt: Emits a string to console
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simConsoleLog(string line)
+```
+
+# Parameters
+
+| Name | Type   | Description                              |
+| ---- | ------ | ---------------------------------------- |
+| line | string | line that will be printed in the console |

--- a/sim/reference/simfunctions/simaddressnonce.mdx
+++ b/sim/reference/simfunctions/simaddressnonce.mdx
@@ -1,0 +1,21 @@
+---
+title: simAddressNonce
+excerpt: Returns the nonce of an address
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simAddressNonce(address add_) internal returns (uint64 nonce)
+```
+
+# Return Values
+
+| Name  | Type   | Description                |
+| ----- | ------ | -------------------------- |
+| nonce | uint64 | the address current nonce. |

--- a/sim/reference/simfunctions/simcalldata.mdx
+++ b/sim/reference/simfunctions/simcalldata.mdx
@@ -1,0 +1,25 @@
+---
+title: simCalldata
+excerpt: Returns the calldata of the (internal) transaction
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simCalldata() internal returns (bytes calldata_)
+```
+
+# Return Values
+
+| Name       | Type  | Description                                          |
+| ---------- | ----- | ---------------------------------------------------- |
+| calldata\_ | bytes | the calldata of the Ethereum transaction/call/create |
+
+# Notes
+
+1. Scoped to the deepest currently executing internal transaction.

--- a/sim/reference/simfunctions/simcalldepth.mdx
+++ b/sim/reference/simfunctions/simcalldepth.mdx
@@ -1,0 +1,25 @@
+---
+title: simCallDepth
+excerpt: Returns the call depth of the currently executing (internal) transaction
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simCallDepth() internal returns (uint64 depth)
+```
+
+# Return Values
+
+| Name  | Type   | Description                                                                                            |
+| ----- | ------ | ------------------------------------------------------------------------------------------------------ |
+| depth | uint64 | the call depth of this Ethereum transaction/call/create; 0 means the start of the Ethereum transaction |
+
+# Notes
+
+1. Scoped to the deepest currently executing internal transaction.

--- a/sim/reference/simfunctions/simcallkind.mdx
+++ b/sim/reference/simfunctions/simcallkind.mdx
@@ -1,0 +1,25 @@
+---
+title: simCallKind
+excerpt: Returns the call kind of the (internal) transaction
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simCallKind() internal returns (enum SimCallKind kind)
+```
+
+# Return Values
+
+| Name | Type             | Description                                                                                                                             |
+| ---- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| kind | enum SimCallKind | the call instruction: call, staticcall, delegatecall, callcode, create or create2. Ethereum transactions will be either call or create. |
+
+# Notes
+
+1. Scoped to the deepest currently executing internal transaction.

--- a/sim/reference/simfunctions/simcodeaddress.mdx
+++ b/sim/reference/simfunctions/simcodeaddress.mdx
@@ -1,0 +1,25 @@
+---
+title: simCodeAddress
+excerpt: Returns the code address of the (internal) transaction
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simCodeAddress() internal returns (address code)
+```
+
+# Return Values
+
+| Name | Type    | Description                                                                                                                                                                                   |
+| ---- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| code | address | the address of the code that will be executed. In a delegate call for example, it will return the address of the delegate. This is different from simTo that will return the contract itself. |
+
+# Notes
+
+1. Scoped to the deepest currently executing internal transaction.

--- a/sim/reference/simfunctions/simcreatedcontract.mdx
+++ b/sim/reference/simfunctions/simcreatedcontract.mdx
@@ -1,0 +1,25 @@
+---
+title: simCreatedContract
+excerpt: Returns the gas remaining after an (internal) transaction
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simCreatedContract() internal returns (address created)
+```
+
+# Return Values
+
+| Name    | Type    | Description                                                                                         |
+| ------- | ------- | --------------------------------------------------------------------------------------------------- |
+| created | address | the new contract address of the Ethereum transaction/call/create, or 0 if no contracts were created |
+
+# Notes
+
+1. Can only be called in a transaction stop hook.

--- a/sim/reference/simfunctions/simemitslog.mdx
+++ b/sim/reference/simfunctions/simemitslog.mdx
@@ -1,0 +1,32 @@
+---
+title: simEmitsLog
+excerpt: Checks if a contract emits a log
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simEmitsLog(address addr, string canonicalSignature) internal returns (bool result)
+```
+
+# Parameters
+
+| Name               | Type    | Description                      |
+| ------------------ | ------- | -------------------------------- |
+| addr               | address | the contract's address           |
+| canonicalSignature | string  | e.g. `Transfer(address,uint256)` |
+
+# Return Values
+
+| Name   | Type | Description                                             |
+| ------ | ---- | ------------------------------------------------------- |
+| result | bool | `true` if the contract emits the log, otherwise `false` |
+
+# Notes
+
+1. If the address passed to `simEmitsLog` is not a contract, the result will be `false`.

--- a/sim/reference/simfunctions/simfrom.mdx
+++ b/sim/reference/simfunctions/simfrom.mdx
@@ -1,0 +1,25 @@
+---
+title: simFrom
+excerpt: Returns the from address of the (internal) transaction
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simFrom() internal returns (address from)
+```
+
+# Return Values
+
+| Name | Type    | Description                                                     |
+| ---- | ------- | --------------------------------------------------------------- |
+| from | address | the address that triggered the Ethereum transaction/call/create |
+
+# Notes
+
+1. Scoped to the deepest currently executing internal transaction.

--- a/sim/reference/simfunctions/simgas.mdx
+++ b/sim/reference/simfunctions/simgas.mdx
@@ -1,0 +1,25 @@
+---
+title: simGas
+excerpt: Returns the amount of gas assigned to this (internal) transaction
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simGas() internal returns (uint64 gas_)
+```
+
+# Return Values
+
+| Name  | Type   | Description                                                      |
+| ----- | ------ | ---------------------------------------------------------------- |
+| gas\_ | uint64 | the amount of gas given to this Ethereum transaction/call/create |
+
+# Notes
+
+1. Scoped to the deepest currently executing internal transaction.

--- a/sim/reference/simfunctions/simgasleft.mdx
+++ b/sim/reference/simfunctions/simgasleft.mdx
@@ -1,0 +1,25 @@
+---
+title: simGasLeft
+excerpt: Returns the gas remaining after an (internal) transaction
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simGasLeft() internal returns (uint64 gas_)
+```
+
+# Return Values
+
+| Name  | Type   | Description                                               |
+| ----- | ------ | --------------------------------------------------------- |
+| gas\_ | uint64 | the gas remaining of the Ethereum transaction/call/create |
+
+# Notes
+
+1. Can only be called in a transaction stop hook.

--- a/sim/reference/simfunctions/simimplementsfunction.mdx
+++ b/sim/reference/simfunctions/simimplementsfunction.mdx
@@ -1,0 +1,32 @@
+---
+title: simImplementsFunction
+excerpt: Checks if a contract implements a function
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simImplementsFunction(address addr, string canonicalSignature) internal returns (bool result)
+```
+
+# Parameters
+
+| Name               | Type    | Description                      |
+| ------------------ | ------- | -------------------------------- |
+| addr               | address | the contract's address           |
+| canonicalSignature | string  | e.g. `transfer(address,uint256)` |
+
+# Return Values
+
+| Name   | Type | Description                                                       |
+| ------ | ---- | ----------------------------------------------------------------- |
+| result | bool | `true` if the contract implements the function, otherwise `false` |
+
+# Notes
+
+1. If the address passed to `simImplementsFunction` is not a contract, the result will be `false`.

--- a/sim/reference/simfunctions/simlogaddress.mdx
+++ b/sim/reference/simfunctions/simlogaddress.mdx
@@ -1,0 +1,25 @@
+---
+title: simLogAddress
+excerpt: Returns the address that emitted a log
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simLogAddress() internal returns (address log)
+```
+
+# Return Values
+
+| Name | Type    | Description                      |
+| ---- | ------- | -------------------------------- |
+| log  | address | the address that emitted the log |
+
+# Notes
+
+1. Can only be called in a log hook.

--- a/sim/reference/simfunctions/simlogdata.mdx
+++ b/sim/reference/simfunctions/simlogdata.mdx
@@ -1,0 +1,25 @@
+---
+title: simLogData
+excerpt: Returns the unindexed event data of a log
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simLogData() internal returns (bytes data)
+```
+
+# Return Values
+
+| Name | Type  | Description         |
+| ---- | ----- | ------------------- |
+| data | bytes | the data of the log |
+
+# Notes
+
+1. Can only be called in a log hook.

--- a/sim/reference/simfunctions/simlogtopic.mdx
+++ b/sim/reference/simfunctions/simlogtopic.mdx
@@ -1,0 +1,31 @@
+---
+title: simLogTopic
+excerpt: Returns a topic from a log
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simLogTopic(uint8 index) internal returns (bytes32 topic)
+```
+
+# Parameters
+
+| Name  | Type  | Description                                |
+| ----- | ----- | ------------------------------------------ |
+| index | uint8 | which topic to get; error if out of bounds |
+
+# Return Values
+
+| Name  | Type    | Description         |
+| ----- | ------- | ------------------- |
+| topic | bytes32 | the requested topic |
+
+# Notes
+
+1. Can only be called in a log hook.

--- a/sim/reference/simfunctions/simlogtopicsize.mdx
+++ b/sim/reference/simfunctions/simlogtopicsize.mdx
@@ -1,0 +1,25 @@
+---
+title: simLogTopicSize
+excerpt: Returns the number of topics in a log
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simLogTopicSize() internal returns (uint64 size)
+```
+
+# Return Values
+
+| Name | Type   | Description                     |
+| ---- | ------ | ------------------------------- |
+| size | uint64 | the number of topics in the log |
+
+# Notes
+
+1. Can only be called in a log hook.

--- a/sim/reference/simfunctions/simparentcodeaddress.mdx
+++ b/sim/reference/simfunctions/simparentcodeaddress.mdx
@@ -1,0 +1,25 @@
+---
+title: simParentCodeAddress
+excerpt: Returns the parent code address of the (internal) transaction
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simParentCodeAddress() internal returns (address parent)
+```
+
+# Return Values
+
+| Name   | Type    | Description                                                                                                                                                                                                                                                                      |
+| ------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| parent | address | the address of the code that triggers the code execution. If a call is made within a delegate call, simParentCodeAddress will return the address of the delegate. This is different from simFrom that will return the address of the contract making the original delegate call. |
+
+# Notes
+
+1. Scoped to the deepest currently executing internal transaction.

--- a/sim/reference/simfunctions/simreadstorage.mdx
+++ b/sim/reference/simfunctions/simreadstorage.mdx
@@ -1,0 +1,28 @@
+---
+title: simReadStorage
+excerpt: Reads storage for specified (contract, slot)
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simReadStorage(address contract_, bytes32 slot) internal returns (bytes32 value)
+```
+
+# Parameters
+
+| Name       | Type    | Description                             |
+| ---------- | ------- | --------------------------------------- |
+| contract\_ | address | address of the contract storage to read |
+| slot       | bytes32 | storage slot to read                    |
+
+# Return Values
+
+| Name  | Type    | Description                                |
+| ----- | ------- | ------------------------------------------ |
+| value | bytes32 | the wanted slot value of the chain context |

--- a/sim/reference/simfunctions/simreturnedvalue.mdx
+++ b/sim/reference/simfunctions/simreturnedvalue.mdx
@@ -1,0 +1,25 @@
+---
+title: simReturnedValue
+excerpt: Returns the bytes returned by an (internal) transaction
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simReturnedValue() internal returns (bytes returnvalue)
+```
+
+# Return Values
+
+| Name        | Type  | Description                                                |
+| ----------- | ----- | ---------------------------------------------------------- |
+| returnvalue | bytes | the bytes returned by the Ethereum transaction/call/create |
+
+# Notes
+
+1. Can only be called in a transaction stop hook.

--- a/sim/reference/simfunctions/simsalt.mdx
+++ b/sim/reference/simfunctions/simsalt.mdx
@@ -1,0 +1,25 @@
+---
+title: simSalt
+excerpt: Returns the salt of a CREATE2 transaction
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simSalt() internal returns (bytes32 salt)
+```
+
+# Return Values
+
+| Name | Type    | Description                                        |
+| ---- | ------- | -------------------------------------------------- |
+| salt | bytes32 | the salt if the ethereum transaction is a create2. |
+
+# Notes
+
+1. Can only be used in a CREATE2 transaction.

--- a/sim/reference/simfunctions/simsetbalance.mdx
+++ b/sim/reference/simfunctions/simsetbalance.mdx
@@ -1,0 +1,24 @@
+---
+title: simSetBalance
+excerpt: Overwrite the native token balance of a given address
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simSetBalance(address contract_, uint256 value) internal
+```
+
+Change the balance of a contract, for the duration of the probe transaction
+
+#### Parameters
+
+| Name       | Type    | Description           |
+| ---------- | ------- | --------------------- |
+| contract\_ | address | contract value to set |
+| value      | uint256 | value to set          |

--- a/sim/reference/simfunctions/simsetstorage.mdx
+++ b/sim/reference/simfunctions/simsetstorage.mdx
@@ -1,0 +1,25 @@
+---
+title: simSetStorage
+excerpt: Overwrites the contents of any (contract, slot)
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simSetStorage(address contract_, bytes32 slot, bytes32 value) internal
+```
+
+Change the value of a storage slot, for the duration of the probe transaction
+
+# Parameters
+
+| Name       | Type    | Description                            |
+| ---------- | ------- | -------------------------------------- |
+| contract\_ | address | the contract to which change the value |
+| slot       | bytes32 | the slot to which change the value     |
+| value      | bytes32 | the new value to set in the slot       |

--- a/sim/reference/simfunctions/simstorageaddress.mdx
+++ b/sim/reference/simfunctions/simstorageaddress.mdx
@@ -1,0 +1,25 @@
+---
+title: simStorageAddress
+excerpt: Returns the address whose slot was read/written
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simStorageAddress() internal returns (address addr)
+```
+
+# Return Values
+
+| Name | Type    | Description                              |
+| ---- | ------- | ---------------------------------------- |
+| addr | address | the address that got its slot read/wrote |
+
+# Notes
+
+1. Can only be called in a storage hook.

--- a/sim/reference/simfunctions/simstoragekey.mdx
+++ b/sim/reference/simfunctions/simstoragekey.mdx
@@ -1,0 +1,25 @@
+---
+title: simStorageKey
+excerpt: Returns the key of the slot that was read/written
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simStorageKey() internal returns (bytes32 key)
+```
+
+# Return Values
+
+| Name | Type    | Description                               |
+| ---- | ------- | ----------------------------------------- |
+| key  | bytes32 | the key of the slot that was read/written |
+
+# Notes
+
+1. Can only be called in a storage hook

--- a/sim/reference/simfunctions/simstoragevalue.mdx
+++ b/sim/reference/simfunctions/simstoragevalue.mdx
@@ -1,0 +1,25 @@
+---
+title: simStorageValue
+excerpt: Returns the value of the slot that was read/written
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simStorageValue() internal returns (bytes32 value)
+```
+
+# Return Values
+
+| Name  | Type    | Description                                 |
+| ----- | ------- | ------------------------------------------- |
+| value | bytes32 | the value of the slot that was read/written |
+
+# Notes
+
+1. Can only be called in a storage hook

--- a/sim/reference/simfunctions/simto.mdx
+++ b/sim/reference/simfunctions/simto.mdx
@@ -1,0 +1,25 @@
+---
+title: simTo
+excerpt: Returns the to address of the (internal) transaction
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simTo() internal returns (address to)
+```
+
+# Return Values
+
+| Name | Type    | Description                                                                                                                                                                        |
+| ---- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| to   | address | the address that receives the Ethereum transaction/call/create; note that for creates the account has already been created, and thus this returns a valid address in that case too |
+
+# Notes
+
+1. Scoped to the deepest currently executing internal transaction.

--- a/sim/reference/simfunctions/simtostring.mdx
+++ b/sim/reference/simfunctions/simtostring.mdx
@@ -1,0 +1,107 @@
+---
+title: simToString
+excerpt: Converts many data types to string for easy logging
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+# address
+
+```solidity
+function simToString(address data) internal returns (string string_)
+```
+
+## Parameters
+
+| Name | Type    | Description          |
+| ---- | ------- | -------------------- |
+| data | address | the value to convert |
+
+## Return Values
+
+| Name     | Type   | Description                                     |
+| -------- | ------ | ----------------------------------------------- |
+| string\_ | string | the given value as a base 16 0x prefixed string |
+
+# bool
+
+```solidity
+function simToString(bool b) internal pure returns (string)
+```
+
+# bytes
+
+```solidity
+function simToString(bytes data) internal returns (string string_)
+```
+
+## Parameters
+
+| Name | Type  | Description          |
+| ---- | ----- | -------------------- |
+| data | bytes | the value to convert |
+
+## Return Values
+
+| Name     | Type   | Description                                     |
+| -------- | ------ | ----------------------------------------------- |
+| string\_ | string | the given value as a base 16 0x prefixed string |
+
+# bytes32
+
+```solidity
+function simToString(bytes32 data) internal returns (string string_)
+```
+
+## Parameters
+
+| Name | Type    | Description          |
+| ---- | ------- | -------------------- |
+| data | bytes32 | the value to convert |
+
+## Return Values
+
+| Name     | Type   | Description                                     |
+| -------- | ------ | ----------------------------------------------- |
+| string\_ | string | the given value as a base 16 0x prefixed string |
+
+# uint256
+
+```solidity
+function simToString(uint256 data) internal returns (string string_)
+```
+
+## Parameters
+
+| Name | Type    | Description          |
+| ---- | ------- | -------------------- |
+| data | uint256 | the value to convert |
+
+## Return Values
+
+| Name     | Type   | Description                         |
+| -------- | ------ | ----------------------------------- |
+| string\_ | string | the given value as a base 10 string |
+
+# uint256\[]
+
+```solidity
+function simToString(uint256[] data) internal returns (string string_)
+```
+
+## Parameters
+
+| Name | Type       | Description          |
+| ---- | ---------- | -------------------- |
+| data | uint256\[] | the value to convert |
+
+## Return Values
+
+| Name     | Type   | Description                         |
+| -------- | ------ | ----------------------------------- |
+| string\_ | string | the given value as a base 10 string |

--- a/sim/reference/simfunctions/simtransactiongaslimit.mdx
+++ b/sim/reference/simfunctions/simtransactiongaslimit.mdx
@@ -1,0 +1,21 @@
+---
+title: simTransactionGasLimit
+excerpt: Returns the gas limit of the transaction
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simTransactionGasLimit() internal returns (uint64 gasLimit)
+```
+
+# Return Values
+
+| Name     | Type   | Description                         |
+| -------- | ------ | ----------------------------------- |
+| gasLimit | uint64 | the ethereum transaction gas limit. |

--- a/sim/reference/simfunctions/simtransactionhash.mdx
+++ b/sim/reference/simfunctions/simtransactionhash.mdx
@@ -1,0 +1,21 @@
+---
+title: simTransactionHash
+excerpt: Returns the transaction hash
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simTransactionHash() internal returns (bytes32 hash)
+```
+
+# Return Values
+
+| Name | Type    | Description                    |
+| ---- | ------- | ------------------------------ |
+| hash | bytes32 | the ethereum transaction hash. |

--- a/sim/reference/simfunctions/simtransactionindex.mdx
+++ b/sim/reference/simfunctions/simtransactionindex.mdx
@@ -1,0 +1,25 @@
+---
+title: simTransactionIndex
+excerpt: Returns the index of the transaction within its block
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simTransactionIndex() internal returns (uint64 index)
+```
+
+# Return Values
+
+| Name  | Type   | Description                                   |
+| ----- | ------ | --------------------------------------------- |
+| index | uint64 | the index of the transaction within its block |
+
+# Notes
+
+1. Can only be called within a transaction hook

--- a/sim/reference/simfunctions/simtransactionstatus.mdx
+++ b/sim/reference/simfunctions/simtransactionstatus.mdx
@@ -1,0 +1,54 @@
+---
+title: simTransactionStatus
+excerpt: Returns the transaction status
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simTransactionStatus() internal returns (uint64 status)
+```
+
+# Return Values
+
+| Name   | Type   | Description                    |
+| ------ | ------ | ------------------------------ |
+| status | uint64 | the current transaction status |
+
+# Responses
+
+| value  | status                                    |
+| ------ | ----------------------------------------- |
+| 0      | EVMC_SUCCESS                              |
+| 1      | EVMC_FAILURE                              |
+| 2      | EVMC_REVERT                               |
+| 3      | EVMC_OUT_OF_GAS                           |
+| 4      | EVMC_INVALID_INSTRUCTION                  |
+| 5      | EVMC_UNDEFINED_INSTRUCTION                |
+| 6      | EVMC_STACK_OVERFLOW                       |
+| 7      | EVMC_STACK_UNDERFLOW                      |
+| 8      | EVMC_BAD_JUMP_DESTINATION                 |
+| 9      | EVMC_INVALID_MEMORY_ADDRESS               |
+| 10     | EVMC_CALL_DEPTH_EXCEEDED                  |
+| 11     | EVMC_STATIC_MODE_VIOLATION                |
+| 12     | EVMC_PRECOMPILE_FAILURE                   |
+| 13     | EVMC_CONTRACT_VALIDATION_FAILURE          |
+| 14     | EVMC_ARGUMENT_OUT_OF_RANGE                |
+| 15     | EVMC_WASM_UNREACHABLE_INSTRUCTION         |
+| 16     | EVMC_WASM_TRAP                            |
+| 17     | EVMC_INSUFFICIENT_BALANCE                 |
+| -1     | EVMC_INTERNAL_ERROR                       |
+| -2     | EVMC_REJECTED                             |
+| -3     | EVMC_OUT_OF_MEMORY                        |
+
+For more details on these statuses, see: [https://evmc.ethereum.org/group__EVMC.html#ga4c0be97f333c050ff45321fcaa34d920](https://evmc.ethereum.org/group__EVMC.html#ga4c0be97f333c050ff45321fcaa34d920)
+
+# Notes
+
+1. Can only be used in a post Transaction hook
+

--- a/sim/reference/simfunctions/simvalue.mdx
+++ b/sim/reference/simfunctions/simvalue.mdx
@@ -1,0 +1,25 @@
+---
+title: simValue
+excerpt: Returns the value sent with the (internal) transaction
+deprecated: false
+hidden: false
+metadata:
+  title: ''
+  description: ''
+  robots: index
+next:
+  description: ''
+---
+```solidity
+function simValue() internal returns (uint256 value)
+```
+
+# Return Values
+
+| Name  | Type    | Description                                              |
+| ----- | ------- | -------------------------------------------------------- |
+| value | uint256 | the value sent with the Ethereum transaction/call/create |
+
+# Notes
+
+1. Scoped to the deepest currently executing internal transaction.


### PR DESCRIPTION
I'm moving sim documentation from docs.sim.io (built on Readme) to here (built on Mintlify). Had to change a bunch of file types and structures but mostly working now. I did not add a sim button to the top nav, so users are unlikely to discover that the documentation is here until that is added. My plan going forward:
1. Merge this PR.
2. Do another PR to update the docs based on recent changes to sim (mostly deprecated features).
3. Add `sim` button in dune docs top nav (or rename to instrument once we've completed that name change).

There are a few more steps required to deprecate the Readme instance/account:
1. Redirect docs.sim.io to the mintlify docs.
2. Change the simAI RAG to pull from mintlify repo instead of readme.
3. Close Readme account.
