### PR TITLE
Sim APIs Info

### DIFF
--- a/api-reference/overview/faq.mdx
+++ b/api-reference/overview/faq.mdx
@@ -9,6 +9,15 @@ There are no major performance differences within a specific performance tier wh
 
 The Dune API gives you programmatic access to the capabilities and data sets that can already be accessed from the Dune web app. The same queries and results exist in the web app, even if created/executed from the API (and vice versa).
 
+#### What are Sim APIs  and how do they differ from the Dune API?
+
+Sim APIs, formerly Echo, are a separate, developer-focused product by Dune, providing realtime access to EVM and SVM blockchain data.
+They are designed for building apps like realtime wallets and AI agents.
+
+[Sim APIs](https://sim.dune.com/) have their own documentation at [docs.sim.dune.com](https://docs.sim.dune.com), use a separate API key (`X-Sim-Api-Key`), and are optimized for low latency, realtime use cases.
+
+The Dune API primarily focuses on executing SQL queries you've written on Dune, managing those queries, and uploading data.
+
 #### How many Requests Per Minute can I make?
 
 The API rate limit currently varies by [subscription plan](https://dune.com/pricing). It's currently 40 per minute on free, 200 per minute on plus, and 1000 per minute on premium.

--- a/api-reference/overview/introduction.mdx
+++ b/api-reference/overview/introduction.mdx
@@ -7,24 +7,32 @@ Dune API provides a variety of endpoints for developers, ranging from low-level,
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/bobGOetmAa4?si=XR9eS3HrnBQqXEnL" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
-## Dune Echo
-  API's specificaly designed for developers to build performant multichain applications with fantastic UX.
-  <CardGroup cols={2}>
-    <Card
-      title="Token Balances"
-      icon="circle-down"
-      href="../../echo/evm/balances"
-    >
-      Fetch real time token balances for accounts on 30+ chains. Data and request latency in the hundreds of milliseconds.
-    </Card>
-    <Card
-      title="Transactions"
-      icon="circle-down"
-      href="../../echo/evm/transactions"
-    >
-      Fetch real time and historical transactions for accounts on 10 chains. Data and request latency in the hundreds of milliseconds.
-    </Card>
-  </CardGroup>
+## Sim APIs
+
+Sim APIs are a dedicated, high-performance suite of developer-focused APIs by Dune, designed for building realtime, multichain apps with exceptional developer experience.
+Sim APIs offer fast and reliable access to EVM and SVM blockchain data.
+
+<CardGroup cols={2}>
+  <Card
+    title="Visit Sim Website"
+    icon="globe"
+    href="https://sim.dune.com"
+  >
+    Explore the official Sim website to learn more about its features, capabilities, and how it can power your apps.
+  </Card>
+  <Card
+    title="View Sim Docs"
+    icon="book-open"
+    href="https://docs.sim.dune.com"
+  >
+    Dive into the comprehensive Sim API docs, including quickstarts, detailed API references, and guides.
+  </Card>
+</CardGroup>
+
+<Note>
+**Sim APIs are an upgraded version of what was previously known as Dune Echo**.
+They offer improved performance and a broader set of features for developers.
+</Note>
 
 ## Custom Endpoints
   <Card


### PR DESCRIPTION
Adding information about Sim APIs to the Dune API Reference Overview page where developers might be most interested in it. I'm also adding a question to the FAQs page.

Removing previous direct references to Dune Echo that were directly on the Dune API Overview page.