### PR TITLE
Fix meta tags for EVM event log pages

### DIFF
--- a/data-catalog/evm/abstract/decoded/event-logs.mdx
+++ b/data-catalog/evm/abstract/decoded/event-logs.mdx
@@ -1,6 +1,6 @@
 ---
-title: Event Logs
-description: Smart Contracts emit event logs when certain predefined actions are completed.
+title: Event Logs - Abstract
+description: Smart contracts on Abstract emit event logs when certain predefined actions are completed.
 ---
 
 import EventLogs from '/snippets/evm/decoded/event-logs-snippet.mdx'

--- a/data-catalog/evm/apechain/decoded/event-logs.mdx
+++ b/data-catalog/evm/apechain/decoded/event-logs.mdx
@@ -1,6 +1,6 @@
 ---
-title: Event Logs
-description: Smart Contracts emit event logs when certain predefined actions are completed.
+title: Event Logs - Apechain
+description: Smart contracts on Apechain emit event logs when certain predefined actions are completed.
 ---
 
 import EventLogs from '/snippets/evm/decoded/event-logs-snippet.mdx'

--- a/data-catalog/evm/arbitrum-nova/decoded/event-logs.mdx
+++ b/data-catalog/evm/arbitrum-nova/decoded/event-logs.mdx
@@ -1,6 +1,6 @@
 ---
-title: Event Logs
-description: Smart Contracts emit event logs when certain predefined actions are completed.
+title: Event Logs - Arbitrum Nova
+description: Smart contracts on Arbitrum Nova emit event logs when certain predefined actions are completed.
 ---
 
 import EventLogs from '/snippets/evm/decoded/event-logs-snippet.mdx'

--- a/data-catalog/evm/arbitrum/decoded/event-logs.mdx
+++ b/data-catalog/evm/arbitrum/decoded/event-logs.mdx
@@ -1,6 +1,6 @@
 ---
-title: Event Logs
-description: Smart Contracts emit event logs when certain predefined actions are completed.
+title: Event Logs - Arbitrum
+description: Smart contracts on Arbitrum emit event logs when certain predefined actions are completed.
 ---
 
 import EventLogs from '/snippets/evm/decoded/event-logs-snippet.mdx'

--- a/data-catalog/evm/avalanche/decoded/event-logs.mdx
+++ b/data-catalog/evm/avalanche/decoded/event-logs.mdx
@@ -1,6 +1,6 @@
 ---
-title: Event Logs
-description: Smart Contracts emit event logs when certain predefined actions are completed.
+title: Event Logs - Avalanche
+description: Smart contracts on Avalanche emit event logs when certain predefined actions are completed.
 ---
 
 import EventLogs from '/snippets/evm/decoded/event-logs-snippet.mdx'

--- a/data-catalog/evm/b3/decoded/event-logs.mdx
+++ b/data-catalog/evm/b3/decoded/event-logs.mdx
@@ -1,6 +1,6 @@
 ---
-title: Event Logs
-description: Smart Contracts emit event logs when certain predefined actions are completed.
+title: Event Logs - B3
+description: Smart contracts on B3 emit event logs when certain predefined actions are completed.
 ---
 
 import EventLogs from '/snippets/evm/decoded/event-logs-snippet.mdx'

--- a/data-catalog/evm/base/decoded/event-logs.mdx
+++ b/data-catalog/evm/base/decoded/event-logs.mdx
@@ -1,6 +1,6 @@
 ---
-title: Event Logs
-description: Smart Contracts emit event logs when certain predefined actions are completed.
+title: Event Logs - Base
+description: Smart contracts on Base emit event logs when certain predefined actions are completed.
 ---
 
 import EventLogs from '/snippets/evm/decoded/event-logs-snippet.mdx'

--- a/data-catalog/evm/berachain/decoded/event-logs.mdx
+++ b/data-catalog/evm/berachain/decoded/event-logs.mdx
@@ -1,6 +1,6 @@
 ---
-title: Event Logs
-description: Smart Contracts emit event logs when certain predefined actions are completed.
+title: Event Logs - Berachain
+description: Smart contracts on Berachain emit event logs when certain predefined actions are completed.
 ---
 
 import EventLogs from '/snippets/evm/decoded/event-logs-snippet.mdx'

--- a/data-catalog/evm/blast/decoded/event-logs.mdx
+++ b/data-catalog/evm/blast/decoded/event-logs.mdx
@@ -1,6 +1,6 @@
 ---
-title: Event Logs
-description: Smart Contracts emit event logs when certain predefined actions are completed.
+title: Event Logs - Blast
+description: Smart contracts on Blast emit event logs when certain predefined actions are completed.
 ---
 
 import EventLogs from '/snippets/evm/decoded/event-logs-snippet.mdx'

--- a/data-catalog/evm/bnb/decoded/event-logs.mdx
+++ b/data-catalog/evm/bnb/decoded/event-logs.mdx
@@ -1,6 +1,6 @@
 ---
-title: Event Logs
-description: Smart Contracts emit event logs when certain predefined actions are completed.
+title: Event Logs - Bnb
+description: Smart contracts on Bnb emit event logs when certain predefined actions are completed.
 ---
 
 import EventLogs from '/snippets/evm/decoded/event-logs-snippet.mdx'

--- a/data-catalog/evm/boba/decoded/event-logs.mdx
+++ b/data-catalog/evm/boba/decoded/event-logs.mdx
@@ -1,6 +1,6 @@
 ---
-title: Event Logs
-description: Smart Contracts emit event logs when certain predefined actions are completed.
+title: Event Logs - Boba
+description: Smart contracts on Boba emit event logs when certain predefined actions are completed.
 ---
 
 import EventLogs from '/snippets/evm/decoded/event-logs-snippet.mdx'


### PR DESCRIPTION
## Summary
- add chain name in event log pages to avoid duplicate meta titles

## Testing
- `python3 /tmp/update_eventlogs.py`

------
https://chatgpt.com/codex/tasks/task_e_686299519468833189a7511e346a63cc