### PR TITLE
Improve SEO metadata for decoded overview pages

### DIFF
--- a/data-catalog/evm/abstract/decoded/overview.mdx
+++ b/data-catalog/evm/abstract/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Abstract Chain Decoded Overview
+description: Simplifying Abstract Chain smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/apechain/decoded/overview.mdx
+++ b/data-catalog/evm/apechain/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: ApeChain Decoded Overview
+description: Simplifying ApeChain smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/arbitrum-nova/decoded/overview.mdx
+++ b/data-catalog/evm/arbitrum-nova/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Arbitrum One Decoded Overview
+description: Simplifying Arbitrum One smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/arbitrum/decoded/overview.mdx
+++ b/data-catalog/evm/arbitrum/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Arbitrum One Decoded Overview
+description: Simplifying Arbitrum One smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/avalanche/decoded/overview.mdx
+++ b/data-catalog/evm/avalanche/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Avalanche C-Chain Decoded Overview
+description: Simplifying Avalanche C-Chain smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/b3/decoded/overview.mdx
+++ b/data-catalog/evm/b3/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: B3 Decoded Overview
+description: Simplifying B3 smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/base/decoded/overview.mdx
+++ b/data-catalog/evm/base/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Base Decoded Overview
+description: Simplifying Base smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/berachain/decoded/overview.mdx
+++ b/data-catalog/evm/berachain/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Berachain Decoded Overview
+description: Simplifying Berachain smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/blast/decoded/overview.mdx
+++ b/data-catalog/evm/blast/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Blast Decoded Overview
+description: Simplifying Blast smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/bnb/decoded/overview.mdx
+++ b/data-catalog/evm/bnb/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: BNB Chain Decoded Overview
+description: Simplifying BNB Chain smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/boba/decoded/overview.mdx
+++ b/data-catalog/evm/boba/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Boba Decoded Overview
+description: Simplifying Boba smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/celo/decoded/overview.mdx
+++ b/data-catalog/evm/celo/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Celo Decoded Overview
+description: Simplifying Celo smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/corn/decoded/overview.mdx
+++ b/data-catalog/evm/corn/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Corn Decoded Overview
+description: Simplifying Corn smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/ethereum/decoded/overview.mdx
+++ b/data-catalog/evm/ethereum/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Ethereum Decoded Overview
+description: Simplifying Ethereum smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/fantom/decoded/overview.mdx
+++ b/data-catalog/evm/fantom/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Fantom Decoded Overview
+description: Simplifying Fantom smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/flare/decoded/overview.mdx
+++ b/data-catalog/evm/flare/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Flare Chain Decoded Overview
+description: Simplifying Flare Chain smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/gnosis/decoded/overview.mdx
+++ b/data-catalog/evm/gnosis/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Gnosis Chain Decoded Overview
+description: Simplifying Gnosis Chain smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/ink/decoded/overview.mdx
+++ b/data-catalog/evm/ink/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Ink Decoded Overview
+description: Simplifying Ink smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/kaia/decoded/overview.mdx
+++ b/data-catalog/evm/kaia/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: KAIA Chain Decoded Overview
+description: Simplifying KAIA Chain smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/lens/decoded/overview.mdx
+++ b/data-catalog/evm/lens/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Lens Decoded Overview
+description: Simplifying Lens smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/linea/decoded/overview.mdx
+++ b/data-catalog/evm/linea/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Linea Decoded Overview
+description: Simplifying Linea smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/mantle/decoded/overview.mdx
+++ b/data-catalog/evm/mantle/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Mantle Decoded Overview
+description: Simplifying Mantle smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/opbnb/decoded/overview.mdx
+++ b/data-catalog/evm/opbnb/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: opBNB Decoded Overview
+description: Simplifying opBNB smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/optimism/decoded/overview.mdx
+++ b/data-catalog/evm/optimism/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Optimism Decoded Overview
+description: Simplifying Optimism smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/plume/decoded/overview.mdx
+++ b/data-catalog/evm/plume/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Plume Decoded Overview
+description: Simplifying Plume smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/polygon-zkEVM/decoded/overview.mdx
+++ b/data-catalog/evm/polygon-zkEVM/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Polygon zkEVM Decoded Overview
+description: Simplifying Polygon zkEVM smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/polygon/decoded/overview.mdx
+++ b/data-catalog/evm/polygon/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Polygon PoS Network Decoded Overview
+description: Simplifying Polygon PoS Network smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/ronin/decoded/overview.mdx
+++ b/data-catalog/evm/ronin/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Ronin Chain Decoded Overview
+description: Simplifying Ronin Chain smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/scroll/decoded/overview.mdx
+++ b/data-catalog/evm/scroll/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Scroll Decoded Overview
+description: Simplifying Scroll smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/sei/decoded/overview.mdx
+++ b/data-catalog/evm/sei/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Sei Decoded Overview
+description: Simplifying Sei smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/sepolia/decoded/overview.mdx
+++ b/data-catalog/evm/sepolia/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Sepolia Testnet Decoded Overview
+description: Simplifying Sepolia Testnet smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/shape/decoded/overview.mdx
+++ b/data-catalog/evm/shape/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Shape Decoded Overview
+description: Simplifying Shape smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/sonic/decoded/overview.mdx
+++ b/data-catalog/evm/sonic/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Sonic Decoded Overview
+description: Simplifying Sonic smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/sophon/decoded/overview.mdx
+++ b/data-catalog/evm/sophon/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Sophon Decoded Overview
+description: Simplifying Sophon smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/unichain/decoded/overview.mdx
+++ b/data-catalog/evm/unichain/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Unichain Decoded Overview
+description: Simplifying Unichain smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/viction/decoded/overview.mdx
+++ b/data-catalog/evm/viction/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Viction Chain Decoded Overview
+description: Simplifying Viction Chain smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/worldchain/decoded/overview.mdx
+++ b/data-catalog/evm/worldchain/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: World Chain Decoded Overview
+description: Simplifying World Chain smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/zksync/decoded/overview.mdx
+++ b/data-catalog/evm/zksync/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: zkSync Decoded Overview
+description: Simplifying zkSync smart contract analysis through human-readable tables.
 icon: "star"
 ---
 

--- a/data-catalog/evm/zora/decoded/overview.mdx
+++ b/data-catalog/evm/zora/decoded/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Overview
-description: Simplifying smart contract analysis through human-readable tables.
+title: Zora Decoded Overview
+description: Simplifying Zora smart contract analysis through human-readable tables.
 icon: "star"
 ---
 


### PR DESCRIPTION
## Summary
- make chain-specific titles and descriptions for all EVM decoded overview pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686299c6d54483319e6e32db5ed5412e