### PR TITLE
Fix meta descriptions for call table pages

### DIFF
--- a/data-catalog/evm/abstract/decoded/call-tables.mdx
+++ b/data-catalog/evm/abstract/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Abstract Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Abstract network in their own tables.
 ---
 

--- a/data-catalog/evm/abstract/decoded/call-tables.mdx
+++ b/data-catalog/evm/abstract/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Abstract network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/apechain/decoded/call-tables.mdx
+++ b/data-catalog/evm/apechain/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: ApeChain Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the ApeChain network in their own tables.
 ---
 

--- a/data-catalog/evm/apechain/decoded/call-tables.mdx
+++ b/data-catalog/evm/apechain/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the ApeChain network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/arbitrum-nova/decoded/call-tables.mdx
+++ b/data-catalog/evm/arbitrum-nova/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Arbitrum Nova Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Arbitrum Nova network in their own tables.
 ---
 

--- a/data-catalog/evm/arbitrum-nova/decoded/call-tables.mdx
+++ b/data-catalog/evm/arbitrum-nova/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Arbitrum Nova network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/arbitrum/decoded/call-tables.mdx
+++ b/data-catalog/evm/arbitrum/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Arbitrum One network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/arbitrum/decoded/call-tables.mdx
+++ b/data-catalog/evm/arbitrum/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Arbitrum One Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Arbitrum One network in their own tables.
 ---
 

--- a/data-catalog/evm/avalanche/decoded/call-tables.mdx
+++ b/data-catalog/evm/avalanche/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Avalanche C-Chain Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Avalanche C-Chain network in their own tables.
 ---
 

--- a/data-catalog/evm/avalanche/decoded/call-tables.mdx
+++ b/data-catalog/evm/avalanche/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Avalanche C-Chain network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/b3/decoded/call-tables.mdx
+++ b/data-catalog/evm/b3/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the B3 network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/b3/decoded/call-tables.mdx
+++ b/data-catalog/evm/b3/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: B3 Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the B3 network in their own tables.
 ---
 

--- a/data-catalog/evm/base/decoded/call-tables.mdx
+++ b/data-catalog/evm/base/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Base network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/base/decoded/call-tables.mdx
+++ b/data-catalog/evm/base/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Base Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Base network in their own tables.
 ---
 

--- a/data-catalog/evm/berachain/decoded/call-tables.mdx
+++ b/data-catalog/evm/berachain/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Berachain network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/berachain/decoded/call-tables.mdx
+++ b/data-catalog/evm/berachain/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Berachain Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Berachain network in their own tables.
 ---
 

--- a/data-catalog/evm/blast/decoded/call-tables.mdx
+++ b/data-catalog/evm/blast/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Blast Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Blast network in their own tables.
 ---
 

--- a/data-catalog/evm/blast/decoded/call-tables.mdx
+++ b/data-catalog/evm/blast/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Blast network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/bnb/decoded/call-tables.mdx
+++ b/data-catalog/evm/bnb/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: BNB Chain Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the BNB Chain network in their own tables.
 ---
 

--- a/data-catalog/evm/bnb/decoded/call-tables.mdx
+++ b/data-catalog/evm/bnb/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the BNB Chain network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/boba/decoded/call-tables.mdx
+++ b/data-catalog/evm/boba/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Boba network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/boba/decoded/call-tables.mdx
+++ b/data-catalog/evm/boba/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Boba Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Boba network in their own tables.
 ---
 

--- a/data-catalog/evm/celo/decoded/call-tables.mdx
+++ b/data-catalog/evm/celo/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Celo network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/celo/decoded/call-tables.mdx
+++ b/data-catalog/evm/celo/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Celo Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Celo network in their own tables.
 ---
 

--- a/data-catalog/evm/corn/decoded/call-tables.mdx
+++ b/data-catalog/evm/corn/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Corn network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/corn/decoded/call-tables.mdx
+++ b/data-catalog/evm/corn/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Corn Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Corn network in their own tables.
 ---
 

--- a/data-catalog/evm/ethereum/decoded/call-tables.mdx
+++ b/data-catalog/evm/ethereum/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Ethereum Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Ethereum network in their own tables.
 ---
 

--- a/data-catalog/evm/ethereum/decoded/call-tables.mdx
+++ b/data-catalog/evm/ethereum/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Ethereum network in their own tables.
 ---
 
 import { DuneEmbed } from '/snippets/dune-embed.mdx'

--- a/data-catalog/evm/fantom/decoded/call-tables.mdx
+++ b/data-catalog/evm/fantom/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Fantom Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Fantom network in their own tables.
 ---
 

--- a/data-catalog/evm/fantom/decoded/call-tables.mdx
+++ b/data-catalog/evm/fantom/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Fantom network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/flare/decoded/call-tables.mdx
+++ b/data-catalog/evm/flare/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Flare network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/flare/decoded/call-tables.mdx
+++ b/data-catalog/evm/flare/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Flare Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Flare network in their own tables.
 ---
 

--- a/data-catalog/evm/gnosis/decoded/call-tables.mdx
+++ b/data-catalog/evm/gnosis/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Gnosis Chain Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Gnosis Chain network in their own tables.
 ---
 

--- a/data-catalog/evm/gnosis/decoded/call-tables.mdx
+++ b/data-catalog/evm/gnosis/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Gnosis Chain network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/ink/decoded/call-tables.mdx
+++ b/data-catalog/evm/ink/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Ink network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/ink/decoded/call-tables.mdx
+++ b/data-catalog/evm/ink/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Ink Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Ink network in their own tables.
 ---
 

--- a/data-catalog/evm/kaia/decoded/call-tables.mdx
+++ b/data-catalog/evm/kaia/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the KAIA network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/kaia/decoded/call-tables.mdx
+++ b/data-catalog/evm/kaia/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: KAIA Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the KAIA network in their own tables.
 ---
 

--- a/data-catalog/evm/lens/decoded/call-tables.mdx
+++ b/data-catalog/evm/lens/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Lens network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/lens/decoded/call-tables.mdx
+++ b/data-catalog/evm/lens/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Lens Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Lens network in their own tables.
 ---
 

--- a/data-catalog/evm/linea/decoded/call-tables.mdx
+++ b/data-catalog/evm/linea/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Linea network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/linea/decoded/call-tables.mdx
+++ b/data-catalog/evm/linea/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Linea Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Linea network in their own tables.
 ---
 

--- a/data-catalog/evm/mantle/decoded/call-tables.mdx
+++ b/data-catalog/evm/mantle/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Mantle network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/mantle/decoded/call-tables.mdx
+++ b/data-catalog/evm/mantle/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Mantle Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Mantle network in their own tables.
 ---
 

--- a/data-catalog/evm/opbnb/decoded/call-tables.mdx
+++ b/data-catalog/evm/opbnb/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the opBNB network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/opbnb/decoded/call-tables.mdx
+++ b/data-catalog/evm/opbnb/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: opBNB Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the opBNB network in their own tables.
 ---
 

--- a/data-catalog/evm/optimism/decoded/call-tables.mdx
+++ b/data-catalog/evm/optimism/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Optimism network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/optimism/decoded/call-tables.mdx
+++ b/data-catalog/evm/optimism/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Optimism Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Optimism network in their own tables.
 ---
 

--- a/data-catalog/evm/plume/decoded/call-tables.mdx
+++ b/data-catalog/evm/plume/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Plume Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Plume network in their own tables.
 ---
 

--- a/data-catalog/evm/plume/decoded/call-tables.mdx
+++ b/data-catalog/evm/plume/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Plume network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/polygon-zkEVM/decoded/call-tables.mdx
+++ b/data-catalog/evm/polygon-zkEVM/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Polygon zkEVM network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/polygon-zkEVM/decoded/call-tables.mdx
+++ b/data-catalog/evm/polygon-zkEVM/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Polygon zkEVM Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Polygon zkEVM network in their own tables.
 ---
 

--- a/data-catalog/evm/polygon/decoded/call-tables.mdx
+++ b/data-catalog/evm/polygon/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Polygon PoS Network network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/polygon/decoded/call-tables.mdx
+++ b/data-catalog/evm/polygon/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Polygon PoS Network Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Polygon PoS Network network in their own tables.
 ---
 

--- a/data-catalog/evm/ronin/decoded/call-tables.mdx
+++ b/data-catalog/evm/ronin/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Ronin Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Ronin network in their own tables.
 ---
 

--- a/data-catalog/evm/ronin/decoded/call-tables.mdx
+++ b/data-catalog/evm/ronin/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Ronin network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/scroll/decoded/call-tables.mdx
+++ b/data-catalog/evm/scroll/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Scroll Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Scroll network in their own tables.
 ---
 

--- a/data-catalog/evm/scroll/decoded/call-tables.mdx
+++ b/data-catalog/evm/scroll/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Scroll network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/sei/decoded/call-tables.mdx
+++ b/data-catalog/evm/sei/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Sei Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Sei network in their own tables.
 ---
 

--- a/data-catalog/evm/sei/decoded/call-tables.mdx
+++ b/data-catalog/evm/sei/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Sei network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/sepolia/decoded/call-tables.mdx
+++ b/data-catalog/evm/sepolia/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Sepolia Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Sepolia network in their own tables.
 ---
 

--- a/data-catalog/evm/sepolia/decoded/call-tables.mdx
+++ b/data-catalog/evm/sepolia/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Sepolia network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/shape/decoded/call-tables.mdx
+++ b/data-catalog/evm/shape/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Shape network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/shape/decoded/call-tables.mdx
+++ b/data-catalog/evm/shape/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Shape Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Shape network in their own tables.
 ---
 

--- a/data-catalog/evm/sonic/decoded/call-tables.mdx
+++ b/data-catalog/evm/sonic/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Sonic Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Sonic network in their own tables.
 ---
 

--- a/data-catalog/evm/sonic/decoded/call-tables.mdx
+++ b/data-catalog/evm/sonic/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Sonic network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/sophon/decoded/call-tables.mdx
+++ b/data-catalog/evm/sophon/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Sophon Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Sophon network in their own tables.
 ---
 

--- a/data-catalog/evm/sophon/decoded/call-tables.mdx
+++ b/data-catalog/evm/sophon/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Sophon network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/unichain/decoded/call-tables.mdx
+++ b/data-catalog/evm/unichain/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Unichain network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/unichain/decoded/call-tables.mdx
+++ b/data-catalog/evm/unichain/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Unichain Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Unichain network in their own tables.
 ---
 

--- a/data-catalog/evm/viction/decoded/call-tables.mdx
+++ b/data-catalog/evm/viction/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Viction network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/viction/decoded/call-tables.mdx
+++ b/data-catalog/evm/viction/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Viction Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Viction network in their own tables.
 ---
 

--- a/data-catalog/evm/worldchain/decoded/call-tables.mdx
+++ b/data-catalog/evm/worldchain/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the World Chain network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/worldchain/decoded/call-tables.mdx
+++ b/data-catalog/evm/worldchain/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: World Chain Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the World Chain network in their own tables.
 ---
 

--- a/data-catalog/evm/zksync/decoded/call-tables.mdx
+++ b/data-catalog/evm/zksync/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the zkSync network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'

--- a/data-catalog/evm/zksync/decoded/call-tables.mdx
+++ b/data-catalog/evm/zksync/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: zkSync Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the zkSync network in their own tables.
 ---
 

--- a/data-catalog/evm/zora/decoded/call-tables.mdx
+++ b/data-catalog/evm/zora/decoded/call-tables.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call Tables
+title: Zora Call Tables
 description: On Dune, we parse all message calls and transactions made to smart contracts on the Zora network in their own tables.
 ---
 

--- a/data-catalog/evm/zora/decoded/call-tables.mdx
+++ b/data-catalog/evm/zora/decoded/call-tables.mdx
@@ -1,6 +1,6 @@
 ---
 title: Call Tables
-description: On Dune, we parse all message calls and transactions made to smart contracts in their own tables.
+description: On Dune, we parse all message calls and transactions made to smart contracts on the Zora network in their own tables.
 ---
 
 import CallTables from '/snippets/evm/decoded/call-tables-snippet.mdx'


### PR DESCRIPTION
## Summary
- mention each chain in the call tables meta descriptions to avoid SEO duplicate content

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68629a5bd5d88331b2b9e7e7fe58227f