### PR TITLE
Link dune query in decoding guide

### DIFF
--- a/web-app/decoding/best-practices.mdx
+++ b/web-app/decoding/best-practices.mdx
@@ -365,6 +365,10 @@ Remember: The goal is to make contract interactions readable and queryable. When
 
 ## Check Your Work
 
+### Check Contract Submissions for Decoding
+
+Use this Dune query to verify your contract submissions and check decoding status: [Contract Submission Checker](https://dune.com/queries/4093792)
+
 ### Check if Contract is decoded on the specific blockchain
 
 ```sql


### PR DESCRIPTION
Add Dune query link to decoding best practices guide to help users check contract submissions.

---

[Slack Thread](https://duneanalytics.slack.com/archives/C092MKT56PP/p1752784965238699?thread_ts=1752784965.238699&cid=C092MKT56PP)