### PR TITLE
Update decoding to show paid team only submission

### DIFF
--- a/web-app/decoding/multichain-decoding.mdx
+++ b/web-app/decoding/multichain-decoding.mdx
@@ -183,6 +183,10 @@ This standardized labeling enables Dune to merge data from different chains into
 
 ### Submitting Multichain Contracts
 
+<Warning>
+**Paid Team Required**: Only users with a paid team subscription can submit multichain contracts. Individual accounts and free teams do not have access to multichain contract submissions. For more information about team plans, see our [pricing page](https://dune.com/pricing).
+</Warning>
+
 <div
   style={{
     position: "relative",


### PR DESCRIPTION
Add a warning to the multichain decoding documentation to clarify that only paid teams can submit multichain contracts.

---
[Slack Thread](https://duneanalytics.slack.com/archives/C092MKT56PP/p1754483560229619?thread_ts=1754483560.229619&cid=C092MKT56PP)

<a href="https://cursor.com/background-agent?bcId=bc-3f8f2048-9b5d-4098-80ed-932ba6d12a73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f8f2048-9b5d-4098-80ed-932ba6d12a73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>