### PR TITLE
Remove roadmap embed from docs home

### DIFF
--- a/home.mdx
+++ b/home.mdx
@@ -59,10 +59,6 @@ You can also level up by following the [crypto data analyst roadmap](https://roa
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/QdcQQKpTBZs?si=k-YAUtxXX44MZT8F" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
-<br/><br/>
-
-<iframe src="https://roadmap.sh/r/embed?id=65fee5b66deb533d6e19fb88" width="100%" height="500px" frameBorder="0"
-></iframe>
 
 ### Why Dune?
 


### PR DESCRIPTION
Remove the Roadmap embed from the docs home page.

---
[Slack Thread](https://duneanalytics.slack.com/archives/C092MKT56PP/p1757064752304699?thread_ts=1757064752.304699&cid=C092MKT56PP)

<a href="https://cursor.com/background-agent?bcId=bc-e8211feb-b310-4f6a-9663-cd081a3e9f85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e8211feb-b310-4f6a-9663-cd081a3e9f85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

