### PR TITLE
Remove hex web example

### DIFF
--- a/api-reference/quickstart/results-eg.mdx
+++ b/api-reference/quickstart/results-eg.mdx
@@ -4,7 +4,7 @@ title: 'Execution & Results'
 
 In this quickstart, we will walk through how to fetch Dune data in Python. 
 
-- 📓 You also can choose to use [this Google Colab Notebook](https://colab.research.google.com/drive/1h3p8Aq7oGZ6lp_R8hOTc0FpX82K1c6d3?usp=sharing) or [this Hex Notebook](https://app.hex.tech/d12aba6a-f113-4485-a72b-b7d812bc2234/hex/401d8569-13f7-43fc-99f4-5b41592ebe44/draft/logic) to get started fast.
+- 📓 You also can choose to use [this Google Colab Notebook](https://colab.research.google.com/drive/1h3p8Aq7oGZ6lp_R8hOTc0FpX82K1c6d3?usp=sharing) to get started fast.
 - ⌨️ For a quickstart on TypeScript, please [download Dune TypeScript SDK](https://github.com/bh2smith/ts-dune-client?tab=readme-ov-file) and [follow this demo project](https://github.com/bh2smith/demo-ts-dune-client).
 
 ### Prerequisites


### PR DESCRIPTION
Remove the Hex Notebook example from the analytics API quickstart.

The Trino connector documentation now provides a more current and comprehensive example for connecting Hex to Dune.

---
[Slack Thread](https://duneanalytics.slack.com/archives/C092MKT56PP/p1757667188016839?thread_ts=1757667188.016839&cid=C092MKT56PP)

<a href="https://cursor.com/background-agent?bcId=bc-6d986a35-ca01-41a1-8132-df79811e753c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d986a35-ca01-41a1-8132-df79811e753c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

