### PR TITLE
Fix documentation link redirect

### DIFF
--- a/query-engine/Functions-and-operators/index.mdx
+++ b/query-engine/Functions-and-operators/index.mdx
@@ -18,7 +18,7 @@ Using ``SHOW FUNCTIONS`` in the query editor returns a list of all available fun
 - [LiveFetch Functions](/query-engine/Functions-and-operators/live-fetch)
 
 ### Trino Base Functions:
-- [Aggregate](query-engine/Functions-and-operators/aggregate)  
+- [Aggregate](/query-engine/Functions-and-operators/aggregate)  
 - [Array](/query-engine/Functions-and-operators/array)  
 - [Binary](/query-engine/Functions-and-operators/binary)  
 - [Bitwise](/query-engine/Functions-and-operators/bitwise)


### PR DESCRIPTION
Fix incorrect 'Aggregate' link by changing its relative path to an absolute path to prevent URL duplication.

The previous relative path caused the browser to incorrectly resolve the link by appending it to the current URL, resulting in a duplicated `query-engine` segment (e.g., `/query-engine/Functions-and-operators/query-engine/Functions-and-operators/aggregate`). Changing it to an absolute path ensures correct resolution.

---
[Slack Thread](https://duneanalytics.slack.com/archives/C092MKT56PP/p1758797410410819?thread_ts=1758797410.410819&cid=C092MKT56PP)

<a href="https://cursor.com/background-agent?bcId=bc-396a75c8-201a-40cf-a7e1-2e12068baefa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-396a75c8-201a-40cf-a7e1-2e12068baefa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

