### PR TITLE
Add warning message to Blast overview about data ingestion discontinuation

### DIFF
--- a/data-catalog/evm/blast/overview.mdx
+++ b/data-catalog/evm/blast/overview.mdx
@@ -6,7 +6,7 @@ description: Blast data on Dune Analytics
 ---
 
 <Warning>
-Starting from 26th September 2025 Dune is not ingesting and indexing Blast data. The historical data of the chain will remain available to be used
+Starting from 26th September 2025 Dune is not ingesting and indexing Blast data. The historical data of the chain will remain available to be used.
 </Warning>
 
 Blast is an Ethereum Layer 2 (L2) that natively provides yield for ETH and stablecoins. Blast is an EVM-compatible, optimistic rollup that raises the baseline yield for users and developers without changing the experience cryptonatives expect. This yield makes it possible to create new business models for Dapps that aren't possible on other L2s.

--- a/data-catalog/evm/blast/overview.mdx
+++ b/data-catalog/evm/blast/overview.mdx
@@ -5,6 +5,10 @@ sidebarTitle: "Overview"
 description: Blast data on Dune Analytics
 ---
 
+<Warning>
+Starting from 26th September 2025 Dune is not ingesting and indexing Blast data. The historical data of the chain will remain available to be used
+</Warning>
+
 Blast is an Ethereum Layer 2 (L2) that natively provides yield for ETH and stablecoins. Blast is an EVM-compatible, optimistic rollup that raises the baseline yield for users and developers without changing the experience cryptonatives expect. This yield makes it possible to create new business models for Dapps that aren't possible on other L2s.
 
 ### Key Features:


### PR DESCRIPTION
## Summary

This PR adds a warning message to the Blast overview page to inform users about upcoming changes to data ingestion.

## Changes

- Added a warning alert component to 
- Informs users that Dune will stop ingesting Blast data starting from September 26th, 2025
- Clarifies that historical data will remain available for querying

## Impact

- Improves user awareness of data availability changes
- Helps users plan their queries and analysis accordingly
- Provides clear communication about the timeline for data ingestion discontinuation

## Testing

- [x] Warning message displays correctly in local development environment
- [x] Alert component renders with proper styling and icon