### PR TITLE
Add Sui blockchain documentation

### DIFF
--- a/data-catalog/sui/checkpoints.mdx
+++ b/data-catalog/sui/checkpoints.mdx
@@ -1,0 +1,39 @@
+---
+title: sui.checkpoints
+sidebarTitle: "Checkpoints"
+description: Description of the sui.checkpoints table on Dune
+---
+
+## Table Description
+Contains checkpoint data from the Sui blockchain. Checkpoints are fundamental units of consensus in Sui, representing a collection of transactions that have been finalized and agreed upon by validators. This table is partitioned by date.
+
+## Column Descriptions
+
+| **Column** | **Type** | **Description** |
+|------------|----------|-----------------|
+| **checkpoint_digest** | string | Unique hash identifier of the checkpoint |
+| **sequence_number** | decimal(20,0) | Sequential number of the checkpoint |
+| **epoch** | decimal(20,0) | Epoch number when the checkpoint was created |
+| **timestamp_ms** | decimal(20,0) | Unix timestamp in milliseconds when the checkpoint was created |
+| **date** | date | Date of when the checkpoint was created |
+| **previous_checkpoint_digest** | string | Hash of the previous checkpoint |
+| **end_of_epoch** | boolean | Whether this checkpoint marks the end of an epoch |
+| **total_gas_cost** | bigint | Total gas cost for all transactions in this checkpoint |
+| **computation_cost** | decimal(20,0) | Total computation cost for transactions in this checkpoint |
+| **storage_cost** | decimal(20,0) | Total storage cost for transactions in this checkpoint |
+| **storage_rebate** | decimal(20,0) | Total storage rebate for transactions in this checkpoint |
+| **non_refundable_storage_fee** | decimal(20,0) | Non-refundable storage fees |
+| **total_transaction_blocks** | decimal(20,0) | Total number of transaction blocks in this checkpoint |
+| **total_transactions** | decimal(20,0) | Total number of transactions in this checkpoint |
+| **total_successful_transaction_blocks** | decimal(20,0) | Total number of successful transaction blocks in this checkpoint |
+| **total_successful_transactions** | decimal(20,0) | Total number of successful transactions in this checkpoint |
+| **network_total_transaction** | decimal(20,0) | Total number of transactions processed by the network up to this checkpoint |
+| **validator_signature** | string | Validator signature for this checkpoint |
+| **_updated_at** | timestamp | Last time the record was updated |
+| **_ingested_at** | timestamp | Time when the record was ingested |
+
+## Table Sample
+
+import { TableSample } from "/snippets/table-sample.mdx";
+
+<TableSample tableSchema="sui" tableName="checkpoints" />

--- a/data-catalog/sui/events.mdx
+++ b/data-catalog/sui/events.mdx
@@ -1,0 +1,34 @@
+---
+title: sui.events
+sidebarTitle: "Events"
+description: Description of the sui.events table on Dune
+---
+
+## Table Description
+Contains event data emitted by smart contracts and system operations on the Sui blockchain. Events provide a way for smart contracts to communicate state changes and important information to external systems. This table is partitioned by date.
+
+## Column Descriptions
+
+| **Column** | **Type** | **Description** |
+|------------|----------|-----------------|
+| **transaction_digest** | string | Hash of the transaction that emitted this event |
+| **event_index** | decimal(20,0) | Index/sequence number of the event within the transaction |
+| **checkpoint** | decimal(20,0) | Checkpoint sequence number containing this event |
+| **epoch** | decimal(20,0) | Epoch number when the event was emitted |
+| **timestamp_ms** | decimal(20,0) | Unix timestamp in milliseconds when the event was emitted |
+| **date** | date | Date of when the event was emitted |
+| **sender** | binary | Binary representation of the sender address |
+| **package** | binary | Binary representation of the package ID that emitted the event |
+| **module** | string | Module name that emitted the event |
+| **event_type** | string | Type of the event (e.g., TransferObject, CoinBalanceChange) |
+| **bcs** | string | Binary Canonical Serialization of the event data |
+| **event_json** | string | JSON representation of the event data |
+| **bcs_length** | decimal(20,0) | Length of the BCS data in bytes |
+| **_updated_at** | timestamp | Last time the record was updated |
+| **_ingested_at** | timestamp | Time when the record was ingested |
+
+## Table Sample
+
+import { TableSample } from "/snippets/table-sample.mdx";
+
+<TableSample tableSchema="sui" tableName="events" />

--- a/data-catalog/sui/move_call.mdx
+++ b/data-catalog/sui/move_call.mdx
@@ -1,0 +1,29 @@
+---
+title: sui.move_call
+sidebarTitle: "Move Call"
+description: Description of the sui.move_call table on Dune
+---
+
+## Table Description
+Contains data about Move function calls executed on the Sui blockchain. This table tracks all smart contract function invocations, including the package, module, and function details. This table is partitioned by date.
+
+## Column Descriptions
+
+| **Column** | **Type** | **Description** |
+|------------|----------|-----------------|
+| **transaction_digest** | string | Hash of the transaction containing this move call |
+| **checkpoint** | decimal(20,0) | Checkpoint sequence number containing this move call |
+| **epoch** | decimal(20,0) | Epoch number when the move call was executed |
+| **timestamp_ms** | decimal(20,0) | Unix timestamp in milliseconds when the move call was executed |
+| **date** | date | Date of when the move call was executed |
+| **package** | binary | Binary representation of the package ID containing the called function |
+| **module** | string | Name of the module containing the called function |
+| **function** | string | Name of the called function |
+| **_updated_at** | timestamp | Last time the record was updated |
+| **_ingested_at** | timestamp | Time when the record was ingested |
+
+## Table Sample
+
+import { TableSample } from "/snippets/table-sample.mdx";
+
+<TableSample tableSchema="sui" tableName="move_call" />

--- a/data-catalog/sui/move_package.mdx
+++ b/data-catalog/sui/move_package.mdx
@@ -1,0 +1,31 @@
+---
+title: sui.move_package
+sidebarTitle: "Move Package"
+description: Description of the sui.move_package table on Dune
+---
+
+## Table Description
+Contains information about Move packages deployed on the Sui blockchain. Move packages are collections of Move modules that define smart contracts and their functionality. This table tracks package deployments, updates, and metadata. This table is partitioned by date.
+
+## Column Descriptions
+
+| **Column** | **Type** | **Description** |
+|------------|----------|-----------------|
+| **package_id** | binary | Binary representation of the unique identifier of the Move package |
+| **checkpoint** | decimal(20,0) | Checkpoint sequence number containing this package operation |
+| **epoch** | decimal(20,0) | Epoch number when the package was deployed/updated |
+| **timestamp_ms** | decimal(20,0) | Unix timestamp in milliseconds when the package was deployed/updated |
+| **date** | date | Date of when the package was deployed/updated |
+| **bcs** | string | Binary Canonical Serialization of the package data |
+| **transaction_digest** | string | Hash of the transaction that deployed/updated this package |
+| **package_version** | decimal(20,0) | Version number of the package |
+| **original_package_id** | binary | Binary representation of the original package ID (for upgrades) |
+| **bcs_length** | decimal(20,0) | Length of the BCS data in bytes |
+| **_updated_at** | timestamp | Last time the record was updated |
+| **_ingested_at** | timestamp | Time when the record was ingested |
+
+## Table Sample
+
+import { TableSample } from "/snippets/table-sample.mdx";
+
+<TableSample tableSchema="sui" tableName="move_package" />

--- a/data-catalog/sui/objects.mdx
+++ b/data-catalog/sui/objects.mdx
@@ -1,0 +1,43 @@
+---
+title: sui.objects
+sidebarTitle: "Objects"
+description: Description of the sui.objects table on Dune
+---
+
+## Table Description
+Contains data about Sui objects, which are the fundamental units of data storage on the Sui blockchain. Unlike traditional blockchains that use key-value stores, Sui uses an object-centric model where data is stored as objects with unique identifiers. This table is partitioned by date.
+
+## Column Descriptions
+
+| **Column** | **Type** | **Description** |
+|------------|----------|-----------------|
+| **object_id** | binary | Binary representation of the unique identifier of the object |
+| **version** | decimal(20,0) | Version number of the object |
+| **digest** | string | Hash digest of the object contents |
+| **type_** | string | Type of the object (e.g., "0x2::coin::Coin<0x2::sui::SUI>") |
+| **checkpoint** | decimal(20,0) | Checkpoint sequence number containing this object operation |
+| **epoch** | decimal(20,0) | Epoch number when the object was created/updated |
+| **timestamp_ms** | decimal(20,0) | Unix timestamp in milliseconds when the object was created/updated |
+| **date** | date | Date of when the object was created/updated |
+| **owner_type** | string | Type of ownership (e.g., "AddressOwner", "ObjectOwner", "Shared", "Immutable") |
+| **owner_address** | binary | Binary representation of the owner address (if applicable) |
+| **object_status** | string | Status of the object (e.g., "Created", "Mutated", "Deleted") |
+| **initial_shared_version** | decimal(20,0) | Initial shared version for shared objects |
+| **previous_transaction** | string | Hash of the previous transaction that modified this object |
+| **has_public_transfer** | boolean | Whether the object can be publicly transferred |
+| **is_consensus** | boolean | Whether this is a consensus object |
+| **storage_rebate** | decimal(20,0) | Storage rebate for this object |
+| **bcs** | string | Binary Canonical Serialization of the object data |
+| **coin_type** | string | Type of coin if this object is a coin |
+| **coin_balance** | decimal(20,0) | Balance of the coin if this object is a coin |
+| **struct_tag** | string | Struct tag of the object |
+| **object_json** | string | JSON representation of the object data |
+| **bcs_length** | decimal(20,0) | Length of the BCS data in bytes |
+| **_updated_at** | timestamp | Last time the record was updated |
+| **_ingested_at** | timestamp | Time when the record was ingested |
+
+## Table Sample
+
+import { TableSample } from "/snippets/table-sample.mdx";
+
+<TableSample tableSchema="sui" tableName="objects" />

--- a/data-catalog/sui/overview.mdx
+++ b/data-catalog/sui/overview.mdx
@@ -1,0 +1,66 @@
+---
+title: Sui Data
+sidebarTitle: "Overview"
+icon: "star"
+description: Sui blockchain data on Dune
+---
+
+## What is Sui?
+
+Sui is a layer 1 blockchain protocol designed for high performance and scalability. The name derives from the Japanese word for water, reflecting the platform's fluid and adaptable nature. Sui features several key innovations:
+
+- **Object-Centric Architecture**: Unlike traditional blockchains that use key-value stores, Sui treats blocks as objects that define assets, enabling more sophisticated programmability.
+- **Delegated Proof-of-Stake (DPoS)**: Energy-efficient consensus mechanism where validators stake SUI tokens to secure the network.
+- **Move Programming Language**: A robust logic engine specifically designed for Sui's object-based approach to blockchain technology.
+- **Parallel Transaction Processing**: Enables high throughput by processing independent transactions simultaneously.
+
+## Sui Networks
+
+Sui operates across multiple networks serving different purposes:
+
+- **Mainnet**: Production network processing real transactions and handling SUI trading and NFT activities
+- **Testnet**: Staging environment for quality assurance and developer testing
+- **Devnet**: Development network for testing new features and latest planned capabilities
+- **Localnet**: Local development environment for optimized workflows
+
+## SUI Token Economics
+
+The native token for Sui is **SUI**, with **MIST** serving as the smallest unit (1 SUI = 1 billion MIST). All transaction costs, including gas fees and data storage, are paid using SUI tokens. The platform uses a delegated proof-of-stake model where validators must stake SUI to participate in consensus, aligning their interests with network security and efficiency.
+
+## Sui Data on Dune
+
+Sui blockchain data is organized into several key tables that capture different aspects of on-chain activity:
+
+<CardGroup cols={2}>
+  <Card title="Checkpoints" icon="cube" href="/data-catalog/sui/checkpoints">
+    Checkpoint data representing finalized collections of transactions agreed upon by validators.
+  </Card>
+
+  <Card title="Events" icon="calendar" href="/data-catalog/sui/events">
+    Event data emitted by smart contracts and system operations on the Sui blockchain.
+  </Card>
+
+  <Card title="Move Call" icon="code" href="/data-catalog/sui/move_call">
+    Data about Move function calls executed on the Sui blockchain.
+  </Card>
+
+  <Card title="Move Package" icon="box" href="/data-catalog/sui/move_package">
+    Information about Move packages deployed on the Sui blockchain.
+  </Card>
+
+  <Card title="Objects" icon="shapes" href="/data-catalog/sui/objects">
+    Sui's unique object-centric data including object states, ownership, and metadata.
+  </Card>
+
+  <Card title="Transaction Objects" icon="link" href="/data-catalog/sui/transaction_objects">
+    Objects involved in transactions, tracking which objects are read, written, or deleted.
+  </Card>
+
+  <Card title="Transactions" icon="arrow-right-arrow-left" href="/data-catalog/sui/transactions">
+    Comprehensive transaction data including transfers, smart contract interactions, and system operations.
+  </Card>
+
+  <Card title="Wrapped Object" icon="layer-group" href="/data-catalog/sui/wrapped_object">
+    Data about wrapped objects and their hierarchical ownership structure.
+  </Card>
+</CardGroup>

--- a/data-catalog/sui/transaction_objects.mdx
+++ b/data-catalog/sui/transaction_objects.mdx
@@ -1,0 +1,30 @@
+---
+title: sui.transaction_objects
+sidebarTitle: "Transaction Objects"
+description: Description of the sui.transaction_objects table on Dune
+---
+
+## Table Description
+Contains data about objects that are involved in transactions on the Sui blockchain. This table tracks which objects are read, written, or deleted in each transaction, providing a comprehensive view of object interactions. This table is partitioned by date.
+
+## Column Descriptions
+
+| **Column** | **Type** | **Description** |
+|------------|----------|-----------------|
+| **object_id** | binary | Binary representation of the unique identifier of the object |
+| **version** | decimal(20,0) | Version of the object in this transaction |
+| **transaction_digest** | string | Hash of the transaction |
+| **checkpoint** | decimal(20,0) | Checkpoint sequence number containing this transaction |
+| **epoch** | decimal(20,0) | Epoch number when the transaction was executed |
+| **timestamp_ms** | decimal(20,0) | Unix timestamp in milliseconds when the transaction was executed |
+| **date** | date | Date of when the transaction was executed |
+| **input_kind** | string | Kind of input for this object (e.g., "Input", "SharedInput", "Receiving") |
+| **object_status** | string | Status of the object (e.g., "Created", "Mutated", "Deleted", "Unchanged") |
+| **_updated_at** | timestamp | Last time the record was updated |
+| **_ingested_at** | timestamp | Time when the record was ingested |
+
+## Table Sample
+
+import { TableSample } from "/snippets/table-sample.mdx";
+
+<TableSample tableSchema="sui" tableName="transaction_objects" />

--- a/data-catalog/sui/transactions.mdx
+++ b/data-catalog/sui/transactions.mdx
@@ -1,0 +1,68 @@
+---
+title: sui.transactions
+sidebarTitle: "Transactions"
+description: Description of the sui.transactions table on Dune
+---
+
+## Table Description
+Contains comprehensive transaction data from the Sui blockchain. This table records all transactions processed on the network, including transfers, smart contract interactions, and system operations. This table is partitioned by date.
+
+## Column Descriptions
+
+| **Column** | **Type** | **Description** |
+|------------|----------|-----------------|
+| **transaction_digest** | string | Unique hash identifier of the transaction |
+| **checkpoint** | decimal(20,0) | Checkpoint sequence number containing this transaction |
+| **epoch** | decimal(20,0) | Epoch number when the transaction was executed |
+| **timestamp_ms** | decimal(20,0) | Unix timestamp in milliseconds when transaction was executed |
+| **date** | date | Date of when the transaction was executed |
+| **sender** | binary | Binary representation of the address that initiated the transaction |
+| **transaction_kind** | string | Type of transaction (e.g., "ProgrammableTransaction", "ChangeEpoch", "Genesis") |
+| **is_system_txn** | boolean | Whether this is a system transaction |
+| **is_sponsored_tx** | boolean | Whether this is a sponsored transaction |
+| **transaction_count** | decimal(20,0) | Number of transactions in the batch |
+| **execution_success** | boolean | Whether the transaction executed successfully |
+| **input** | decimal(20,0) | Number of input objects |
+| **shared_input** | decimal(20,0) | Number of shared input objects |
+| **gas_coins** | decimal(20,0) | Number of gas coins used |
+| **created** | decimal(20,0) | Number of objects created |
+| **mutated** | decimal(20,0) | Number of objects mutated |
+| **deleted** | decimal(20,0) | Number of objects deleted |
+| **transfers** | decimal(20,0) | Number of transfers performed |
+| **split_coins** | decimal(20,0) | Number of coin splits performed |
+| **merge_coins** | decimal(20,0) | Number of coin merges performed |
+| **publish** | decimal(20,0) | Number of packages published |
+| **upgrade** | decimal(20,0) | Number of package upgrades |
+| **others** | decimal(20,0) | Number of other operations |
+| **move_calls** | decimal(20,0) | Number of move calls made |
+| **packages** | string | Packages involved in the transaction |
+| **gas_owner** | binary | Binary representation of the gas owner address |
+| **gas_object_id** | binary | Binary representation of the gas object ID |
+| **gas_object_sequence** | decimal(20,0) | Sequence number of the gas object |
+| **gas_object_digest** | string | Digest of the gas object |
+| **gas_budget** | decimal(20,0) | Gas budget allocated for the transaction |
+| **total_gas_cost** | bigint | Total gas cost for the transaction |
+| **computation_cost** | decimal(20,0) | Computation cost component of gas |
+| **storage_cost** | decimal(20,0) | Storage cost component of gas |
+| **storage_rebate** | decimal(20,0) | Storage rebate received |
+| **non_refundable_storage_fee** | decimal(20,0) | Non-refundable storage fees |
+| **gas_price** | decimal(20,0) | Gas price for the transaction |
+| **raw_transaction** | string | Raw transaction data |
+| **has_zklogin_sig** | boolean | Whether the transaction has zkLogin signature |
+| **has_upgraded_multisig** | boolean | Whether the transaction has upgraded multisig |
+| **transaction_json** | string | JSON representation of the transaction |
+| **effects_json** | string | JSON representation of the transaction effects |
+| **transaction_position** | decimal(20,0) | Position of the transaction within the checkpoint |
+| **events_digest** | string | Digest of events emitted by the transaction |
+| **transaction_data_bcs_length** | decimal(20,0) | Length of transaction data BCS in bytes |
+| **effects_bcs_length** | decimal(20,0) | Length of effects BCS in bytes |
+| **events_bcs_length** | decimal(20,0) | Length of events BCS in bytes |
+| **signatures_bcs_length** | decimal(20,0) | Length of signatures BCS in bytes |
+| **_updated_at** | timestamp | Last time the record was updated |
+| **_ingested_at** | timestamp | Time when the record was ingested |
+
+## Table Sample
+
+import { TableSample } from "/snippets/table-sample.mdx";
+
+<TableSample tableSchema="sui" tableName="transactions" />

--- a/data-catalog/sui/wrapped_object.mdx
+++ b/data-catalog/sui/wrapped_object.mdx
@@ -1,0 +1,30 @@
+---
+title: sui.wrapped_object
+sidebarTitle: "Wrapped Object"
+description: Description of the sui.wrapped_object table on Dune
+---
+
+## Table Description
+Contains data about wrapped objects on the Sui blockchain. Wrapped objects are objects that have been wrapped by another object, creating a hierarchical ownership structure. This table tracks the wrapping relationships and metadata. This table is partitioned by date.
+
+## Column Descriptions
+
+| **Column** | **Type** | **Description** |
+|------------|----------|-----------------|
+| **object_id** | binary | Binary representation of the unique identifier of the wrapped object |
+| **root_object_id** | binary | Binary representation of the unique identifier of the root object that contains this wrapped object |
+| **root_object_version** | decimal(20,0) | Version of the root object |
+| **checkpoint** | decimal(20,0) | Checkpoint sequence number containing this wrapping operation |
+| **epoch** | decimal(20,0) | Epoch number when the object was wrapped |
+| **timestamp_ms** | decimal(20,0) | Unix timestamp in milliseconds when the object was wrapped |
+| **date** | date | Date of when the object was wrapped |
+| **json_path** | string | JSON path to the wrapped object within the root object |
+| **struct_tag** | string | Struct tag of the wrapped object |
+| **_updated_at** | timestamp | Last time the record was updated |
+| **_ingested_at** | timestamp | Time when the record was ingested |
+
+## Table Sample
+
+import { TableSample } from "/snippets/table-sample.mdx";
+
+<TableSample tableSchema="sui" tableName="wrapped_object" />

--- a/mint.json
+++ b/mint.json
@@ -2615,6 +2615,22 @@
           ]
         },
         {
+          "group": "Sui",
+          "icon": "database",
+          "iconType": "solid",
+          "pages": [
+            "data-catalog/sui/overview",
+            "data-catalog/sui/checkpoints",
+            "data-catalog/sui/events",
+            "data-catalog/sui/move_call",
+            "data-catalog/sui/move_package",
+            "data-catalog/sui/objects",
+            "data-catalog/sui/transaction_objects",
+            "data-catalog/sui/transactions",
+            "data-catalog/sui/wrapped_object"
+          ]
+        },
+        {
           "group": "TON",
           "icon": "database",
           "iconType": "solid",


### PR DESCRIPTION
## Overview
This PR adds comprehensive documentation for the Sui blockchain data available on Dune.

## Changes Made

### New Documentation Files
- **Overview page** () - Introduction to Sui blockchain and its unique features
- **8 table documentation files** with accurate schemas based on manifest files:
  -  - Checkpoint data and consensus information
  -  - Smart contract and system event logs  
  -  - Move function call execution data
  -  - Move package deployment information
  -  - Sui's object-centric data model
  -  - Object interactions in transactions
  -  - Comprehensive transaction data
  -  - Wrapped object relationships

### Navigation Updates
- Updated  to include Sui section in Data Catalog navigation
- Positioned alphabetically after Stellar and before TON

## Key Features
- ✅ Accurate column schemas based on actual manifest files
- ✅ Proper data types (binary, decimal(20,0), etc.)
- ✅ Complete column descriptions for all tables
- ✅ Consistent formatting matching existing documentation style
- ✅ Comprehensive overview with Sui-specific blockchain information

## Testing
- All files follow the established documentation format
- Navigation properly integrated
- Schema accuracy verified against source manifests

This documentation provides users with complete reference material for querying Sui blockchain data on Dune.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Sui blockchain data catalog documentation (overview + 8 tables) and integrate a new "Sui" section into navigation.
> 
> - **Docs**:
>   - Add Sui data catalog pages under `data-catalog/sui/`:
>     - `overview.mdx`
>     - `checkpoints.mdx`
>     - `events.mdx`
>     - `move_call.mdx`
>     - `move_package.mdx`
>     - `objects.mdx`
>     - `transaction_objects.mdx`
>     - `transactions.mdx`
>     - `wrapped_object.mdx`
> - **Navigation**:
>   - Update `mint.json` to add a new "Sui" group with links to the above pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d26676140ecaa34f7ff7d4dd9f99fe72d18d8155. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->