### PR TITLE
Add Query Templates documentation page

### DIFF
--- a/learning/how-tos/query-templates.mdx
+++ b/learning/how-tos/query-templates.mdx
@@ -1,0 +1,125 @@
+---
+title: "Query Templates"
+description: "Pre-built query templates to jumpstart your Dune journey with common blockchain analytics patterns"
+icon: "template"
+---
+
+# Query Templates
+
+Jump start your Dune journey with our collection of pre-built query templates. These templates let you easily select wallets, tokens, and contracts and track their key actions over time.
+
+<Note>
+**Need a specific template?** Don't see what you're looking for? [Request a new template](https://form.typeform.com/to/ZNhlPZQY) and we'll consider adding it to our collection.
+</Note>
+
+## Tokens
+
+Track token flows, balances, and holder activity across different token standards.
+
+<CardGroup cols={2}>
+  <Card title="Contract Balance and Flow Monitoring - ERC20 Token" icon="coins" href="https://dune.com/queries/5823843">
+    Track the net flows of an ERC20 token into contracts, over a given time period
+  </Card>
+  <Card title="Wallet Balance and Flow Monitoring - ERC20 Token" icon="wallet" href="https://dune.com/queries/5823857">
+    Track the net flows of top holders (or a list of addresses) for an ERC20 token, over a given time period
+  </Card>
+  <Card title="Contract Balance and Flow Monitoring - NFT Token (721/1155)" icon="image" href="https://dune.com/queries/5823861">
+    Track the net flows of an NFT token into contracts, over a given time period
+  </Card>
+  <Card title="Wallet Balance and Flow Monitoring - NFT Token (721/1155)" icon="user" href="https://dune.com/queries/5833534">
+    Track the net flows of top holders (or a list of addresses) for an NFT token, over a given time period
+  </Card>
+</CardGroup>
+
+## Trades
+
+Monitor trading activity across DEXs and NFT marketplaces.
+
+<CardGroup cols={2}>
+  <Card title="DEX Trade Monitoring" icon="chart-line" href="https://dune.com/queries/5833536">
+    Track trading volume, price movements, and liquidity patterns for token pairs
+  </Card>
+  <Card title="NFT Trade Monitoring" icon="image" href="https://dune.com/queries/5833538">
+    Monitor NFT trading activity, floor prices, and collection performance
+  </Card>
+</CardGroup>
+
+## Contracts
+
+Analyze smart contract interactions and usage patterns.
+
+<CardGroup cols={2}>
+  <Card title="New Wallets Calling a Contract" icon="user-plus" href="https://dune.com/queries/5833540">
+    Identify new users interacting with a specific smart contract over time
+  </Card>
+  <Card title="New Contracts Calling Another Contract" icon="code" href="https://dune.com/queries/5833541">
+    Track which new contracts are calling a specific contract
+  </Card>
+  <Card title="Trending Contracts Called by Tracked Wallet" icon="trending-up" href="https://dune.com/queries/5833544">
+    Discover which contracts a tracked wallet is calling most frequently
+  </Card>
+</CardGroup>
+
+## Farcaster
+
+Analyze social activity and user behavior on the Farcaster protocol.
+
+<CardGroup cols={2}>
+  <Card title="Identify trending users who hold a token" icon="users" href="https://dune.com/queries/5833549">
+    Find Farcaster users who hold specific tokens and are gaining social traction
+  </Card>
+  <Card title="Identify trending channels" icon="hashtag" href="https://dune.com/queries/5833553">
+    Discover which Farcaster channels are gaining popularity and activity
+  </Card>
+  <Card title="Track trending users someone has interacted with" icon="user-friends" href="https://dune.com/queries/5833555">
+    Analyze the social network of a specific user to find trending connections
+  </Card>
+</CardGroup>
+
+## How to Use Templates
+
+1. **Click on any template** above to open it in the Dune query editor
+2. **Customize the parameters** using the template's input fields:
+   - **Token Symbol**: Choose the token you want to track
+   - **Token Contract**: Paste the contract address if the token isn't in our database
+   - **Blockchain**: Select the blockchain network
+   - **Time Period**: Set the number of days to analyze
+   - **Filters**: Adjust minimum thresholds and other parameters
+3. **Run the query** to see your results
+4. **Save and share** your customized query
+
+## Template Categories Explained
+
+### **Tokens**
+Perfect for analyzing token economics, holder behavior, and token flows. Use these templates to understand how tokens move between wallets and contracts.
+
+### **Trades** 
+Ideal for market analysis, price tracking, and trading pattern identification. Essential for understanding market dynamics and liquidity.
+
+### **Contracts**
+Great for smart contract analytics, user adoption tracking, and protocol interaction analysis. Use these to understand how users interact with specific protocols.
+
+### **Farcaster**
+Designed for social analytics on the Farcaster protocol. Perfect for understanding community dynamics, influencer identification, and social trends.
+
+## Getting Started
+
+1. **Choose your category** based on what you want to analyze
+2. **Select a template** that matches your use case
+3. **Customize the parameters** to fit your specific needs
+4. **Run and iterate** to refine your analysis
+
+<Info>
+**Pro Tip**: Start with a template and modify it to create your own unique queries. Templates are designed to be building blocks for more complex analysis.
+</Info>
+
+## Need Help?
+
+- **Query Editor Guide**: Learn how to use the Dune query editor effectively
+- **Writing Efficient Queries**: Optimize your queries for better performance
+- **Data Catalog**: Explore available data sources and tables
+- **Community**: Join our Discord for help and inspiration
+
+---
+
+**Don't see what you need?** [Request a new template](https://form.typeform.com/to/ZNhlPZQY) and we'll consider adding it to our collection.

--- a/learning/how-tos/query-templates.mdx
+++ b/learning/how-tos/query-templates.mdx
@@ -7,7 +7,7 @@ icon: "template"
 Jump start your Dune journey with our collection of pre-built query templates. These templates let you easily select wallets, tokens, and contracts and track their key actions over time.
 
 <Note>
-**Need a specific template?** Don't see what you're looking for? [Request a new template](https://form.typeform.com/to/ZNhlPZQY) and we'll consider adding it to our collection.
+**Need a specific template?** Don't see what you're looking for? [Request a new template](https://docs.google.com/forms/d/e/1FAIpQLSeDjR0908lRRroCzRHSD9SnBKSS5hox-_AbLJahH7ZmBuf5hA/viewform?usp=header) and we'll consider adding it to our collection.
 </Note>
 
 ## Tokens
@@ -120,4 +120,4 @@ Designed for social analytics on the Farcaster protocol. Perfect for understandi
 
 ---
 
-**Don't see what you need?** [Request a new template](https://form.typeform.com/to/ZNhlPZQY) and we'll consider adding it to our collection.
+**Don't see what you need?** [Request a new template](https://docs.google.com/forms/d/e/1FAIpQLSeDjR0908lRRroCzRHSD9SnBKSS5hox-_AbLJahH7ZmBuf5hA/viewform?usp=header) and we'll consider adding it to our collection.

--- a/learning/how-tos/query-templates.mdx
+++ b/learning/how-tos/query-templates.mdx
@@ -4,8 +4,6 @@ description: "Pre-built query templates to jumpstart your Dune journey with comm
 icon: "template"
 ---
 
-# Query Templates
-
 Jump start your Dune journey with our collection of pre-built query templates. These templates let you easily select wallets, tokens, and contracts and track their key actions over time.
 
 <Note>
@@ -55,7 +53,7 @@ Analyze smart contract interactions and usage patterns.
   <Card title="New Contracts Calling Another Contract" icon="code" href="https://dune.com/queries/5833541">
     Track which new contracts are calling a specific contract
   </Card>
-  <Card title="Trending Contracts Called by Tracked Wallet" icon="trending-up" href="https://dune.com/queries/5833544">
+  <Card title="Trending Contracts Called by Tracked Wallet" icon="chart-line" href="https://dune.com/queries/5833544">
     Discover which contracts a tracked wallet is calling most frequently
   </Card>
 </CardGroup>
@@ -71,7 +69,7 @@ Analyze social activity and user behavior on the Farcaster protocol.
   <Card title="Identify trending channels" icon="hashtag" href="https://dune.com/queries/5833553">
     Discover which Farcaster channels are gaining popularity and activity
   </Card>
-  <Card title="Track trending users someone has interacted with" icon="user-friends" href="https://dune.com/queries/5833555">
+  <Card title="Track trending users someone has interacted with" icon="users" href="https://dune.com/queries/5833555">
     Analyze the social network of a specific user to find trending connections
   </Card>
 </CardGroup>

--- a/mint.json
+++ b/mint.json
@@ -71,6 +71,7 @@
       "group": "Jump right in",
       "pages": [
         "learning/how-tos/create-your-first-query",
+        "learning/how-tos/query-templates",
         "learning/how-tos/create-new-content",
         "learning/how-tos/create-your-first-visualization",
         "learning/how-tos/navigate-query-editor",


### PR DESCRIPTION
- Create comprehensive query templates page with all 12 templates
- Organize templates by category: Tokens, Trades, Contracts, Farcaster
- Include direct links to Dune queries and Typeform for requests
- Add navigation entry in mint.json under 'Jump right in' section
- Provide usage instructions and category explanations
- Replace modal interface with permanent documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a new `learning/how-tos/query-templates` docs page with categorized template links and usage guidance, and add it to the "Jump right in" navigation.
> 
> - **Docs**:
>   - **New Page**: Add `learning/how-tos/query-templates.mdx` with categorized templates: `Tokens`, `Trades`, `Contracts`, `Farcaster` (12 linked Dune queries).
>   - **Guides**: Include usage steps, category explanations, getting started tips, and request links.
> - **Navigation**:
>   - Add `learning/how-tos/query-templates` to `mint.json` under "Jump right in".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 062eca37b94de4ff43dc86fc0bf4e2d1a87e07f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->