### PR TITLE
Handle large integer precision in snowflake

### DIFF
--- a/datashare/datashare-snowflake.mdx
+++ b/datashare/datashare-snowflake.mdx
@@ -62,6 +62,29 @@ WHERE hash_hex = '0xefb2e2c26974f72d9f3f04c693db73ecc679dd60'
 
 Use VARBINARY for exact matching (e.g., token IDs), DOUBLE for calculations.
 
+If you need full precision when doing arithmetic, you must work with the VARBINARY field:
+- You can convert the binary to `DECIMAL(38,0)` if you are fine with the smaller range (up to 38 digits vs. 78 for `UINT256`).
+- Any values larger than `DECIMAL(38,0)` will overflow and must be handled as `NULL` or excluded.
+
+Here is an example conversion query:
+
+```sql
+select
+  IFF(
+    SUBSTR(amount_raw, 1, 17) != TO_BINARY(REPEAT('0', 34), 'HEX'), -- check for overflow
+    NULL, -- if overflow, return null
+    TO_NUMBER(
+      TO_VARCHAR(SUBSTR(amount_raw, 18, 15), 'HEX'),
+      REPEAT('X', 30)
+    )::NUMBER(38,0) -- convert last 15 bytes to decimal
+  ) AS amount_raw_converted,
+  amount_raw,
+  amount,
+  tx_hash
+from prod_datashares.tokens.transfers
+limit 100;
+```
+
 ## Details
 
 - **Freshness**: hourly or daily depending on requirements


### PR DESCRIPTION
Add documentation and a SQL example for converting `VARBINARY` `UINT256` values to `DECIMAL(38,0)` in Snowflake to address user reports of rounding errors.

---
[Slack Thread](https://duneanalytics.slack.com/archives/C096PD4T5K6/p1758892984962739?thread_ts=1758892984.962739&cid=C096PD4T5K6)

<a href="https://cursor.com/background-agent?bcId=bc-4253511d-3017-4d64-ac99-e2a1c8576c33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4253511d-3017-4d64-ac99-e2a1c8576c33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds guidance and an example SQL snippet for converting VARBINARY uint256 to DECIMAL(38,0) with overflow handling in Snowflake.
> 
> - **Docs**: Update `datashare/datashare-snowflake.mdx`
>   - Add guidance for full-precision arithmetic using `VARBINARY` fields.
>   - Document conversion to `DECIMAL(38,0)` and note overflow limits/NULL handling.
>   - Include example SQL converting `amount_raw` via `IFF`, `SUBSTR`, `TO_BINARY`, `TO_VARCHAR`, and `TO_NUMBER`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32359d2d32da8266a0be2a7cdd32f7e7e0fcde2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->